### PR TITLE
Move TED URLs to HTTPS

### DIFF
--- a/scraper/WebVTTcreator.py
+++ b/scraper/WebVTTcreator.py
@@ -84,4 +84,4 @@ class WebVTTcreator():
       return True
 
 if __name__ == '__main__':
-    WebVTTcreator('http://www.ted.com/talks/subtitles/id/1907/lang/en')
+    WebVTTcreator('https://www.ted.com/talks/subtitles/id/1907/lang/en')

--- a/scraper/utils.py
+++ b/scraper/utils.py
@@ -26,7 +26,7 @@ def build_video_page(page):
     Url builder for TED talk video pages.
     Appending the page number to the 'page' parameter.
     """
-    return 'http://new.ted.com/talks/browse?page={}'.format(page)
+    return 'https://new.ted.com/talks/browse?page={}'.format(page)
 
 
 def build_subtitle_pages(video_id, language_list):
@@ -37,7 +37,7 @@ def build_subtitle_pages(video_id, language_list):
     """
 
     for language in language_list:
-        page = 'http://www.ted.com/talks/subtitles/id/{}/lang/{}' \
+        page = 'https://www.ted.com/talks/subtitles/id/{}/lang/{}' \
             .format(video_id, language['languageCode'])
         language['link'] = page
 

--- a/scraper/webscraper.py
+++ b/scraper/webscraper.py
@@ -32,7 +32,7 @@ from collections import defaultdict
 class Scraper():
 
     # The base Url. The link gives you a grid of all TED talks.
-    BASE_URL = 'http://new.ted.com/talks/browse'
+    BASE_URL = 'https://new.ted.com/talks/browse'
     # BeautifulSoup instance
     soup = None
     # Page count
@@ -173,7 +173,7 @@ class Scraper():
         # [
         #     {
         #         'languageCode': u'en',
-        #         'link': 'http://www.ted.com/talks/subtitles/id/1907/lang/en',
+        #         'link': 'https://www.ted.com/talks/subtitles/id/1907/lang/en',
         #         'languageName': u'English'
         #     }
         # ]

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     long_description=readme,
     author="Kiwix",
     author_email="contact@kiwix.org",
-    url='http://github.com/openzim/ted',
+    url='https://github.com/openzim/ted',
     keywords="ted zim kiwix openzim offline",
     license="GPL-3.0",
     packages=find_packages('.'),


### PR DESCRIPTION
As ted.com as fully moved to HTTPS we should better use it directly as been systematically redirected.