### PR TITLE
Addresses #19 - Fix and update scraping and data dumping

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Pillow
-beautifulsoup4==4.3.2
+beautifulsoup4==4.9.0
 python-dateutil==2.6.1
 zimscraperlib==1.0.4
 requests>=2.23,<3.0

--- a/ted2zim/WebVTTcreator.py
+++ b/ted2zim/WebVTTcreator.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim: ai ts=4 sts=4 et sw=4 nu
 
-"""
-Class for creating a WebVTT subtitles file from the
-JSON subtitles format from www.TED.com
-"""
-__title__ = "WebVTTcreator"
-__author__ = "Rashiq Ahmad"
-__license__ = "GPLv3"
+# Class for creating a WebVTT subtitles file from the
+# JSON subtitles format from www.TED.com
 
 import json
 import requests
@@ -18,11 +15,10 @@ class WebVTTcreator:
     WebVTTdocument = "WEBVTT\n\n"
 
     def __init__(self, url, offset=0):
-        """
-        Loads the json representation of the subtitles form the given
-        Url and decodes it.
-        Creates a WebVtt document off it and saves it in a .vtt file.
-        """
+
+        # Loads the json representation of the subtitles form the given
+        # Url and decodes it.
+        # Creates a WebVtt document off it and saves it in a .vtt file.
         dl_ok = False
         while not dl_ok:
             r = requests.get(url)
@@ -39,16 +35,15 @@ class WebVTTcreator:
             return False
 
     def create_WebVtt(self, json, offset):
-        """
-        Create the WebVTT file from the given decoded json.
-        Structure of a WebVTT file:
 
-        WebVTT
+        # Create the WebVTT file from the given decoded json.
+        # Structure of a WebVTT file:
 
-        00:00:00.000 --> 00:00:00.000
-        [start time --> end time]
-        'content'
-        """
+        # WebVTT
+
+        # 00:00:00.000 --> 00:00:00.000
+        # [start time --> end time]
+        # 'content'
         if "captions" in json:
             for subtitle in json["captions"]:
                 startTime = int(subtitle["startTime"]) + offset
@@ -64,9 +59,8 @@ class WebVTTcreator:
                 self.WebVTTdocument += content + "\n\n"
 
     def time_string(self, ms):
-        """
-        Create the '00:00:00.000' string representation of the time.
-        """
+
+        # Create the '00:00:00.000' string representation of the time.
         hours, remainder = divmod(ms, 3600000)
         minutes, remainder = divmod(remainder, 60000)
         seconds, miliseconds = divmod(remainder, 1000)
@@ -77,8 +71,8 @@ class WebVTTcreator:
 
     def is_json(self, json_data):
         try:
-            json_object = json.loads(json_data)
-        except ValueError, e:
+            json.loads(json_data)
+        except ValueError:
             return False
         return True
 

--- a/ted2zim/constants.py
+++ b/ted2zim/constants.py
@@ -13,6 +13,10 @@ NAME = ROOT_DIR.name
 with open(ROOT_DIR.joinpath("VERSION"), "r") as fh:
     VERSION = fh.read().strip()
 
+ENCODER_VERSION = "v1"
+
 SCRAPER = f"{NAME} {VERSION}"
+
+MAX_SOURCE_VIDEOS_PER_PAGE = 36
 
 logger = getLogger(NAME, level=logging.DEBUG)

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -15,17 +15,20 @@ def main():
     )
 
     parser.add_argument(
-        "--categories",
+        "--topics",
         help="Comma-seperated list of topics to scrape. Should be exactly same as given on ted.com/talks",
         required=True,
     )
 
     parser.add_argument(
-        "--max-videos",
+        "--max-videos-per-topic",
         help="Max number of videos to scrape in each topic. Pass 'max' if you want to scrape all",
         required=True,
+        default=9999,
+        type=int
     )
 
+    # would be removed soon
     parser.add_argument(
         "--transcode2webm",
         help="Whether to transcode videos to webm format",

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -25,7 +25,7 @@ def main():
         help="Max number of videos to scrape in each topic. Pass 'max' if you want to scrape all",
         required=True,
         default=9999,
-        type=int
+        type=int,
     )
 
     # would be removed soon

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -15,10 +15,28 @@ def main():
     )
 
     parser.add_argument(
+        "--categories",
+        help="Comma-seperated list of topics to scrape. Should be exactly same as given on ted.com/talks",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--max-videos",
+        help="Max number of videos to scrape in each topic. Pass 'max' if you want to scrape all",
+        required=True,
+    )
+
+    parser.add_argument(
         "--transcode2webm",
         help="Whether to transcode videos to webm format",
         action="store_true",
-        required=True,
+    )
+
+    parser.add_argument(
+        "--output",
+        help="Output folder for ZIM file or build folder",
+        default="/output",
+        dest="output_dir",
     )
 
     parser.add_argument(

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -14,7 +14,7 @@ import sys
 from bs4 import BeautifulSoup
 from urllib.parse import urljoin
 from time import sleep
-from os import path # to be removed soon
+from os import path  # to be removed soon
 
 from .utils import download_from_site, build_subtitle_pages
 from .constants import ROOT_DIR, SCRAPER, MAX_SOURCE_VIDEOS_PER_PAGE, logger
@@ -33,12 +33,7 @@ class Ted2Zim:
     videos = []
 
     def __init__(
-        self,
-        max_videos_per_topic,
-        topics,
-        output_dir,
-        transcode2webm,
-        debug,
+        self, max_videos_per_topic, topics, output_dir, transcode2webm, debug,
     ):
 
         # output directory

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -687,7 +687,7 @@ def create_zim(static_folder, zim_path, title, description, name):
         "zim": zim_path,
         "scraper": "Ted scraper : https://github.com/openzim/ted",
         "source": "https://new.ted.com",
-        "tags": "_topic:ted;ted",
+        "tags": "_category:ted;ted",
         "name": name,
     }
 

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -1,129 +1,145 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-Class for scraping www.TED.com.
-"""
-__title__ = "webscraper"
-__author__ = "Rashiq Ahmad"
-__license__ = "GPLv3"
+# vim: ai ts=4 sts=4 et sw=4 nu
 
-import os
-from os import path
-import sys
-import shutil
-import distutils.dir_util
-from datetime import datetime
-from sys import platform as _platform
-import envoy
-import subprocess
-import datetime
 import dateutil.parser
 import requests
-from time import sleep
-from bs4 import BeautifulSoup
-from urlparse import urljoin
-import utils
 import json
-from jinja2 import Environment, FileSystemLoader
-from WebVTTcreator import WebVTTcreator
-from collections import defaultdict
+import pathlib
+import jinja2
+import shutil
+import datetime
+import sys
+
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin
+from time import sleep
+from os import path # to be removed soon
+
+from .utils import create_absolute_link, download_from_site, build_subtitle_pages
+from .constants import ROOT_DIR, SCRAPER, MAX_SOURCE_VIDEOS_PER_PAGE, logger
+from .WebVTTcreator import WebVTTcreator
 
 
 class Ted2Zim:
 
     # The base Url. The link gives you a grid of all TED talks.
-    BASE_URL = "https://new.ted.com/talks/browse"
+    BASE_URL = "https://ted.com/talks"
     # BeautifulSoup instance
     soup = None
     # Page count
     pages = None
     # List of links to all TED talks
     videos = []
-    # Categories of the TED talks
-    categories = [
-        "technology",
-        "entertainment",
-        "design",
-        "business",
-        "science",
-        "global issues",
-    ]
 
-    def __init__(self, transcode2webm):
-        """
-        Extract number of video pages. Generate the specific
-        video page from it and srape it.
-        """
-        self.build_dir = path.join(os.getcwd(), "..", "build")
-        self.scraper_dir = path.join(self.build_dir, "TED", "scraper")
-        self.html_dir = path.join(self.build_dir, "TED", "html")
-        self.zim_dir = path.join(self.build_dir, "TED", "zim")
-        self.meta_data_dir = path.join(self.scraper_dir, "TED.json")
-        self.templates_dir = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)), "templates"
-        )
+    def __init__(
+        self,
+        max_videos,
+        categories,
+        output_dir,
+        transcode2webm,
+        debug,
+    ):
+
+        # output directory
+        self.output_dir = pathlib.Path(output_dir).expanduser().resolve()
+
+        if max_videos.isdigit():
+            self.max_videos = int(max_videos)
+        elif max_videos == "max":
+            self.max_videos = "max"
+
+        self.categories = [c.strip().replace(" ", "+") for c in categories.split(",")]
+
         self.transcode2webm = transcode2webm
-        if not bin_is_present("zimwriterfs"):
-            sys.exit("zimwriterfs is not available, please install it.")
 
-    def extract_page_number(self):
-        """
-        Extract the number of video pages by looking at the
-        pagination div at the bottom. Select all <a>-tags in it and
-        return the last element in the list. That's our total count
-        """
-        self.soup = BeautifulSoup(utils.download_from_site(self.BASE_URL).text)
-        pages = self.soup.select("div.pagination a.pagination__item")[-1]
-        return int(pages.text)
+        self.debug = debug
+
+    @property
+    def root_dir(self):
+        return ROOT_DIR
+
+    @property
+    def templates_dir(self):
+        return self.root_dir.joinpath("templates")
+
+    @property
+    def build_dir(self):
+        return self.output_dir.joinpath("build")
+
+    @property
+    def ted_videos_json(self):
+        return self.output_dir.joinpath("ted_videos.json")
+
+    @property
+    def ted_categories_json(self):
+        return self.output_dir.joinpath("ted_categories.json")
 
     def extract_all_video_links(self):
-        """
-        This method will build the specifiv video site by appending
-        the page number to the 'page' parameter to the url.
-        We will iterate through every page and extract every
-        video link. The video link is extracted in `extract_videos()`.
-        """
-        for page in range(1, self.extract_page_number()):
-            url = utils.build_video_page(page)
-            html = utils.download_from_site(url).text
-            self.soup = BeautifulSoup(html)
-            self.extract_videos()
-            print("Finished scraping page " + str(page))
 
-    def extract_videos(self):
-        """
-        All videos are embedded in a <div> with the class name 'row'.
-        We are searching for the div inside this div, that has an <a>-tag
-        with the class name 'media__image', because this is the relative
-        link to the representative TED talk. We have to turn this relative
-        link to an absolute link. This is done through the `utils` class.
-        """
-        print(
-            "Video found : " + str(len(self.soup.select("div.row div.media__image a")))
-        )  # DEBUG
-        for video in self.soup.select("div.row div.media__image a"):
-            url = utils.create_absolute_link(self.BASE_URL, video["href"])
+        # extracts all video links for different categories
+        # it iterates over the categories and then over pages to get required number of video links
+        for category in self.categories:
+            logger.debug(f"Fetching video links for category: {category}")
+            category_url = f"{self.BASE_URL}?topics%5B%5D={category}"
+            self.soup = BeautifulSoup(
+                download_from_site(category_url).text, features="html.parser"
+            )
+            video_allowance = None
+            page = 1
+            tot_videos_scraped = 0
+            if self.max_videos == "max":
+                video_allowance = 9999
+            else:
+                video_allowance = self.max_videos
+            while video_allowance:
+                url = f"{category_url}&page={page}"
+                html = download_from_site(url).text
+                self.soup = BeautifulSoup(html, features="html.parser")
+                num_videos_extracted = self.extract_videos(video_allowance)
+                if num_videos_extracted == 0:
+                    break
+                video_allowance -= num_videos_extracted
+                tot_videos_scraped += num_videos_extracted
+                page += 1
+            logger.info(f"Total video links found in {category}: {tot_videos_scraped}")
+
+    def extract_videos(self, video_allowance):
+
+        # all videos are embedded in a <div> with the class name 'row'.
+        # we are searching for the div inside this div, that has an <a>-tag
+        # with the class name 'media__image', because this is the relative
+        # link to the representative TED talk. We have to turn this relative
+        # link to an absolute link. This is done through the `utils` class
+        videos = self.soup.select("div.row div.media__image a")
+        if len(videos) > video_allowance:
+            videos = videos[0:video_allowance]
+        logger.debug(f"{str(len(videos))} videos found on current page")
+        for video in videos:
+            url = create_absolute_link(self.BASE_URL, video["href"])
             self.extract_video_info(url)
+            logger.debug(f"Done {video['href']}")
+        return len(videos)
 
     def extract_video_info(self, url):
-        """
-        Extract the meta-data of the video:
-        Speaker, the profession of the speaker, a short biography of
-        the speaker, the link to a picture of the speaker, title,
-        publishing date, view count, description of the TED talk,
-        direct download link to the video, download link to the subtitle
-        files and a link to a thumbnail of the video.
-        """
-        self.soup = BeautifulSoup(utils.download_from_site(url).text)
 
+        # Extract the meta-data of the video:
+        # Speaker, the profession of the speaker, a short biography of
+        # the speaker, the link to a picture of the speaker, title,
+        # publishing date, view count, description of the TED talk,
+        # direct download link to the video, download link to the subtitle
+        # files and a link to a thumbnail of the video.
         # Every TED video page has a <script>-tag with a Javascript
         # object with JSON in it. We will just stip away the object
         # signature and load the json to extract meta-data out of it.
-        json_data = self.soup.select("div.talks-main script")
-        if len(json_data) == 0:
+        self.soup = BeautifulSoup(download_from_site(url).text, features="html.parser")
+        div = self.soup.find("div", attrs={"class": "talks-main"})
+        script_tags_within_div = div.find_all("script")
+        if len(script_tags_within_div) == 0:
+            logger.error("The required script tag containing video meta is not present")
             return
-        json_data = json_data[-1].text
-
+        json_data_tag = script_tags_within_div[-1]
+        json_data = json_data_tag.string
         json_data = " ".join(json_data.split(",", 1)[1].split(")")[:-1])
         json_data = json.loads(json_data)["__INITIAL_DATA__"]
 
@@ -177,9 +193,11 @@ class Ted2Zim:
         # Extract the download link of the TED talk video
         downloads = talk_info["downloads"]["nativeDownloads"]
         if not downloads:
+            logger.error("No direct download links found for the video")
             return
         video_link = downloads["medium"]
         if not video_link:
+            logger.error("No link to download video in medium quality")
             return
 
         # Extract the video Id of the TED talk video.
@@ -199,53 +217,58 @@ class Ted2Zim:
             {"languageName": lang["languageName"], "languageCode": lang["languageCode"]}
             for lang in talk_info["player_talks"][0]["languages"]
         ]
-        subtitles = utils.build_subtitle_pages(video_id, subtitles)
+        subtitles = build_subtitle_pages(video_id, subtitles)
 
         # Extract the keywords for the TED talk
         keywords = self.soup.find("meta", attrs={"name": "keywords"})["content"]
         keywords = [key.strip() for key in keywords.split(",")]
 
-        # Extract the ratings list for the TED talk
-        # ratings = talk_info["ratings"]
-
-        # Append the meta-data to a list
-        self.videos.append(
-            [
-                {
-                    "id": video_id,
-                    "title": title.encode("utf-8", "ignore"),
-                    "description": description.encode("utf-8", "ignore"),
-                    "speaker": speaker.encode("utf-8", "ignore"),
-                    "speaker_profession": speaker_profession.encode("utf-8", "ignore"),
-                    "speaker_bio": speaker_bio.encode("utf-8", "ignore"),
-                    "speaker_picture": speaker_picture.encode("utf-8", "ignore"),
-                    "date": date.encode("utf-8", "ignore"),
-                    "thumbnail": thumbnail.encode("utf-8", "ignore"),
-                    "video_link": video_link.encode("utf-8", "ignore"),
-                    "length": length,
-                    "subtitles": subtitles,
-                    "keywords": keywords,
-                    "ratings": ratings,
-                }
-            ]
-        )
+        # Check if video ID already exists. If not, append data to self.videos
+        if not any(video[0].get("id", None) == video_id for video in self.videos):
+            self.videos.append(
+                [
+                    {
+                        "id": video_id,
+                        "title": title,
+                        "description": description,
+                        "speaker": speaker,
+                        "speaker_profession": speaker_profession,
+                        "speaker_bio": speaker_bio,
+                        "speaker_picture": speaker_picture,
+                        "date": date,
+                        "thumbnail": thumbnail,
+                        "video_link": video_link,
+                        "length": length,
+                        "subtitles": subtitles,
+                        "keywords": keywords,
+                    }
+                ]
+            )
+            logger.debug(f"Successfully inserted video {video_id} into video list")
+        else:
+            logger.debug(f"Video {video_id} already present in video list")
 
     def dump_data(self):
-        """
-        Dump all the data about every TED talk in a json file
-        inside the 'build' folder.
-        """
-        # Prettified json dump
-        data = json.dumps(self.videos, indent=4, separators=(",", ": "))
+
+        # Dump all the data about every TED talk in a json file
+        # inside the 'build' folder.
+        logger.debug(
+            f"Dumping {len(self.videos)} videos into {self.ted_videos_json} and {len(self.categories)} categories into {self.ted_categories_json}"
+        )
+        video_data = json.dumps(self.videos, indent=4, separators=(",", ": "))
+        categories_data = json.dumps(self.categories, indent=4, separators=(",", ": "))
 
         # Check, if the folder exists. Create it, if it doesn't.
-        if not path.exists(self.scraper_dir):
-            os.makedirs(self.scraper_dir)
+        if not self.build_dir.exists():
+            self.build_dir.mkdir(parents=True)
 
-        # Create or override the 'TED.json' file in the build
-        # directory with the video data gathered from the scraper.
-        with open(self.scraper_dir + "/TED.json", "w") as ted_file:
-            ted_file.write(data)
+        # Create or override the json files in the build
+        # directory with the video data gathered from the scraper
+        # and category data.
+        with open(self.ted_videos_json, "w") as f:
+            f.write(video_data)
+        with open(self.ted_categories_json, "w") as f:
+            f.write(categories_data)
 
     def render_video_pages(self):
         """
@@ -637,15 +660,15 @@ class Ted2Zim:
     def run(self):
         self.extract_all_video_links()
         self.dump_data()
-        self.download_subtitles()
-        self.download_video_data()
-        self.render_welcome_page()
-        self.render_video_pages()
-        self.copy_files_to_rendering_directory()
-        self.generate_category_data()
-        self.encode_videos()
-        self.resize_thumbnails()
-        self.create_zims()
+        # self.download_subtitles()
+        # self.download_video_data()
+        # self.render_welcome_page()
+        # self.render_video_pages()
+        # self.copy_files_to_rendering_directory()
+        # self.generate_category_data()
+        # self.encode_videos()
+        # self.resize_thumbnails()
+        # self.create_zims()
 
 
 def resize_image(image_path):

--- a/ted2zim/utils.py
+++ b/ted2zim/utils.py
@@ -2,16 +2,8 @@
 # -*- coding: utf-8 -*-
 # vim: ai ts=4 sts=4 et sw=4 nu
 
-from urllib.parse import urljoin
 from time import sleep
 import requests
-
-
-def create_absolute_link(base, rel_url):
-    # Creates a absolute Url out of a relative link.
-    # Will return the given second parameter, if it's already
-    # an absolute link.
-    return urljoin(base, rel_url)
 
 
 def build_subtitle_pages(video_id, language_list):

--- a/ted2zim/utils.py
+++ b/ted2zim/utils.py
@@ -1,41 +1,23 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim: ai ts=4 sts=4 et sw=4 nu
 
-from urlparse import urljoin
+from urllib.parse import urljoin
 from time import sleep
 import requests
 
-"""
-Utils class for the scraper.
-"""
-__title__ = "utils"
-__author__ = "Rashiq Ahmad"
-__license__ = "GPLv3"
-
 
 def create_absolute_link(base, rel_url):
-    """
-    Creates a absolute Url out of a relative link.
-    Will return the given second parameter, if it's already
-    an absolute link.
-    """
+    # Creates a absolute Url out of a relative link.
+    # Will return the given second parameter, if it's already
+    # an absolute link.
     return urljoin(base, rel_url)
 
 
-def build_video_page(page):
-    """
-    Url builder for TED talk video pages.
-    Appending the page number to the 'page' parameter.
-    """
-    return "https://new.ted.com/talks/browse?page={}".format(page)
-
-
 def build_subtitle_pages(video_id, language_list):
-    """
-    Url builder for the json subtitles page for TED talks.
-    Building it from the video specific Id and the language
-    we want the subtitles in.
-    """
-
+    # Url builder for the json subtitles page for TED talks.
+    # Building it from the video specific Id and the language
+    # we want the subtitles in.
     for language in language_list:
         page = "https://www.ted.com/talks/subtitles/id/{}/lang/{}".format(
             video_id, language["languageCode"]


### PR DESCRIPTION
Addresses #19 by scraping topicwise. The scraping logic has been updated and following new arguments are introduced -
- --topics - Comma-seperated list of all categories (spelling should be same as in the list on ted.com/talks
- --max-videos-per-topic - Maximum number of videos to scrape in each topic
- --output - The output folder

The scraper now uses a supplied folder as the output folder and directly builds files into the build directory inside it. This is a similar structure as the youtube scraper. Previously it had 3 directories inside the output folder.

Since the scraper now scrapes with a given list of topics, it now dumps 2 json files, one containing the video data and the other containing the list of topics.

Status - The scraping logic and json dumping work now. It can be tested as follows -
```
ted2zim --topics="augmented reality" --max-videos-per-topic=55 --debug --output="output"
```
The edge case of passing wrong topic names would be handled later. Currently, it would just dump the supplied topics in the category data json file.

It would be very easy to add language filtering in this scraping logic. It will be addressed soon.