### PR TITLE
Fail on wrong arguments, remove unused code

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,16 @@ python3 setup.py install
 2. Run the command 'ted2zim' as follows
 
 ```
-usage: ted2zim [-h] --topics TOPICS --max-videos-per-topic
-               MAX_VIDEOS_PER_TOPIC [--output OUTPUT_DIR] --name NAME
-               [--format {mp4,webm}] [--low-quality] [--no-zim]
-               [--zim-file FNAME] [--language LANGUAGE] --title TITLE
-               --description DESCRIPTION --creator CREATOR
+usage: ted2zim [-h] --topics TOPICS
+               [--max-videos-per-topic MAX_VIDEOS_PER_TOPIC]
+               [--output OUTPUT_DIR] --name NAME [--format {mp4,webm}]
+               [--low-quality] [--no-zim] [--zim-file FNAME]
+               [--language LANGUAGE] [--title TITLE]
+               [--description DESCRIPTION] [--creator CREATOR]
                [--publisher PUBLISHER] [--tags TAGS] [--keep] [--debug]
+               [--version]
 
-Scraper to create ZIM files from TED videos
+Scraper to create ZIM files from TED talks
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -43,14 +45,14 @@ optional arguments:
                         be appended)
   --format {mp4,webm}   Format to download/transcode video to. webm is smaller
   --low-quality         Re-encode video using stronger compression
-  --no-zim              Don't produce a ZIM file, create HTML folder only.
+  --no-zim              Don't produce a ZIM file, create build folder only.
   --zim-file FNAME      ZIM file name (based on --name if not provided)
   --language LANGUAGE   ISO-639-3 (3 chars) language code of content
-  --title TITLE         Custom title for your project and ZIM. Default to
-                        Channel name (of first video if playlists)
+  --title TITLE         Custom title for your project and ZIM. Default value -
+                        TED Collection
   --description DESCRIPTION
                         Custom description for your project and ZIM. Default
-                        to Channel name (of first video if playlists)
+                        value - A selection of several topics' videos from TED
   --creator CREATOR     Name of content creator
   --publisher PUBLISHER
                         Custom publisher name (ZIM metadata)
@@ -58,6 +60,7 @@ optional arguments:
                         category:ted, ted, and _videos:yes added automatically
   --keep                Don't erase build folder on start (for debug/devel)
   --debug               Enable verbose output
+  --version             Display scraper version and exit
 ```
 
 Example usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 python-dateutil==2.8.1
 zimscraperlib>=1.0.5,<1.1
 requests>=2.23,<3.0
-Pillow==7.1.2
 beautifulsoup4==4.9.0
 Jinja2==2.10.1

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -75,13 +75,11 @@ def main():
     parser.add_argument(
         "--title",
         help="Custom title for your project and ZIM. Default value - TED Collection",
-        default="TED Collection",
     )
 
     parser.add_argument(
         "--description",
         help="Custom description for your project and ZIM. Default value - A selection of several topics' videos from TED",
-        default="A selection of several topics' videos from TED",
     )
 
     parser.add_argument("--creator", help="Name of content creator", default="TED")

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -23,7 +23,6 @@ def main():
     parser.add_argument(
         "--max-videos-per-topic",
         help="Max number of videos to scrape in each topic. Default behaviour is to scrape all",
-        required=False,
         default=9999,
         type=int,
     )
@@ -33,7 +32,6 @@ def main():
         help="Output folder for ZIM file or build folder",
         default="/output",
         dest="output_dir",
-        required=False
     )
 
     parser.add_argument(
@@ -76,21 +74,17 @@ def main():
 
     parser.add_argument(
         "--title",
-        help="Custom title for your project and ZIM. Default to Channel name (of first video if playlists)",
-        required=False,
-        default=""
+        help="Custom title for your project and ZIM. Default value - TED Collection",
+        default="TED Collection",
     )
 
     parser.add_argument(
         "--description",
-        help="Custom description for your project and ZIM. Default to Channel name (of first video if playlists)",
-        required=False,
-        default=""
+        help="Custom description for your project and ZIM. Default value - A selection of several topics' videos from TED",
+        default="A selection of several topics' videos from TED",
     )
 
-    parser.add_argument(
-        "--creator", help="Name of content creator", required=False, default="TED"
-    )
+    parser.add_argument("--creator", help="Name of content creator", default="TED")
 
     parser.add_argument(
         "--publisher", help="Custom publisher name (ZIM metadata)", default="Kiwix"
@@ -124,6 +118,12 @@ def main():
     logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
 
     try:
+        if args.max_videos_per_topic < 1:
+            raise ValueError(
+                "Maximum number of videos to scrape per topic must be greater than or equal to 1"
+            )
+        if not args.topics:
+            raise ValueError("Please supply topics to parse")
         scraper = Ted2Zim(**dict(args._get_kwargs()))
         scraper.run()
     except Exception as exc:

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -11,7 +11,7 @@ from .scraper import Ted2Zim
 
 def main():
     parser = argparse.ArgumentParser(
-        prog=NAME, description="Scraper to create ZIM files from TED videos",
+        prog=NAME, description="Scraper to create ZIM files from TED talks",
     )
 
     parser.add_argument(
@@ -33,6 +33,7 @@ def main():
         help="Output folder for ZIM file or build folder",
         default="/output",
         dest="output_dir",
+        required=False
     )
 
     parser.add_argument(
@@ -58,7 +59,7 @@ def main():
 
     parser.add_argument(
         "--no-zim",
-        help="Don't produce a ZIM file, create HTML folder only.",
+        help="Don't produce a ZIM file, create build folder only.",
         action="store_true",
         default=False,
     )
@@ -76,13 +77,15 @@ def main():
     parser.add_argument(
         "--title",
         help="Custom title for your project and ZIM. Default to Channel name (of first video if playlists)",
-        required=True,
+        required=False,
+        default=""
     )
 
     parser.add_argument(
         "--description",
         help="Custom description for your project and ZIM. Default to Channel name (of first video if playlists)",
-        required=True,
+        required=False,
+        default=""
     )
 
     parser.add_argument(
@@ -108,6 +111,13 @@ def main():
 
     parser.add_argument(
         "--debug", help="Enable verbose output", action="store_true", default=False
+    )
+
+    parser.add_argument(
+        "--version",
+        help="Display scraper version and exit",
+        action="version",
+        version=SCRAPER,
     )
 
     args = parser.parse_args()

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -3,21 +3,17 @@
 # vim: ai ts=4 sts=4 et sw=4 nu
 
 import dateutil.parser
-import requests
 import json
 import pathlib
 import jinja2
 import shutil
 import datetime
-import sys
-import time
-import math
 
 from bs4 import BeautifulSoup
 from urllib.parse import urljoin
 from time import sleep
 from zimscraperlib.zim import ZimInfo, make_zim_file
-from zimscraperlib.download import save_file, save_large_file
+from zimscraperlib.download import save_large_file
 
 from .utils import download_from_site, build_subtitle_pages
 from .constants import ROOT_DIR, SCRAPER, logger

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -145,15 +145,15 @@ class Ted2Zim:
 
     def update_title_and_description(self):
         if len(self.topics) > 1:
-            if self.title is None:
+            if not self.title:
                 self.title = "TED Collection"
-            if self.description is None:
+            if not self.description:
                 self.description = "A selection of TED videos from several topics"
         else:
-            if self.title is None:
+            if not self.title:
                 topic_str = self.topics[0].replace("+", " ")
                 self.title = f"{topic_str.capitalize()} from TED"
-            if self.description is None:
+            if not self.description:
                 self.description = f"A selection of {topic_str} videos from TED"
 
     def extract_videos(self, video_allowance):

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -78,8 +78,6 @@ class Ted2Zim:
             homepage="index.html",
             language=self.language,
             tags=self.tags + ["_category:ted", "ted", "_videos:yes"],
-            title=self.title,
-            description=self.description,
             creator=self.creator,
             publisher=self.publisher,
             name=self.name,
@@ -143,6 +141,20 @@ class Ted2Zim:
                 )
         if not self.topics:
             raise ValueError("Wrong topic(s) were supplied. No videos found")
+        self.update_title_and_description()
+
+    def update_title_and_description(self):
+        if len(self.topics) > 1:
+            if self.title is None:
+                self.title = "TED Collection"
+            if self.description is None:
+                self.description = "A selection of TED videos from several topics"
+        else:
+            if self.title is None:
+                topic_str = self.topics[0].replace("+", " ")
+                self.title = f"{topic_str.capitalize()} from TED"
+            if self.description is None:
+                self.description = f"A selection of {topic_str} videos from TED"
 
     def extract_videos(self, video_allowance):
 
@@ -521,6 +533,7 @@ class Ted2Zim:
                 self.fname if self.fname else f"{self.name}_{period}.zim"
             )
             logger.info("building ZIM file")
+            self.zim_info.update(title=self.title, description=self.description)
             logger.debug(self.zim_info.to_zimwriterfs_args())
             make_zim_file(self.build_dir, self.output_dir, self.fname, self.zim_info)
             if not self.keep_build_dir:

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -136,6 +136,13 @@ class Ted2Zim:
                 tot_videos_scraped += num_videos_extracted
                 page += 1
             logger.info(f"Total video links found in {topic}: {tot_videos_scraped}")
+            if tot_videos_scraped == 0:
+                self.topics.remove(topic)
+                logger.debug(
+                    f"Removed topic {topic} from topic list as it had no videos"
+                )
+        if not self.topics:
+            raise ValueError("Wrong topic(s) were supplied. No videos found")
 
     def extract_videos(self, video_allowance):
 
@@ -284,7 +291,7 @@ class Ted2Zim:
         # Dump all the data about every TED talk in a json file
         # inside the 'build' folder.
         logger.debug(
-            f"Dumping {len(self.videos)} videos into {self.ted_videos_json} and {len(self.topics)} topics into {self.ted_topics_json}"
+            f"Dumping {len(self.videos)} videos into {self.ted_videos_json} and {len(self.topics)} topic(s) into {self.ted_topics_json}"
         )
         video_data = json.dumps(self.videos, indent=4)
         topics_data = json.dumps(self.topics, indent=4)


### PR DESCRIPTION
This fixes the following issues -
- #38 - The scraper now fails if the user supplies wrong topics, no topics or if --max-videos-per-topic < 1
- #33 - It now makes --title and --description optional and adds default values for them
- #32 - Unused imports have now been removed
- #23 - Pillow has been removed from requirements and all have a fixed version/version range

Apart from this, it introduces a new argument --version which prints the scraper version