### PR TITLE
Add videojs-ogvjs as fallback media player

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,6 @@ build
 # JS deps
 ted2zim/templates/assets/chosen/
 ted2zim/templates/assets/jquery.min.js
+ted2zim/templates/assets/ogvjs/
+ted2zim/templates/assets/videojs-ogvjs.js
 ted2zim/templates/assets/videojs/

--- a/get_js_deps.sh
+++ b/get_js_deps.sh
@@ -39,3 +39,25 @@ rm -f chosen_v1.8.7.zip
 
 echo "getting jquery.min.js"
 curl -L -o $ASSETS_PATH/jquery.min.js https://code.jquery.com/jquery-3.5.1.min.js
+
+echo "getting ogv.js"
+curl -L -O https://github.com/brion/ogv.js/releases/download/1.6.1/ogvjs-1.6.1.zip
+rm -rf $ASSETS_PATH/ogvjs
+unzip -o ogvjs-1.6.1.zip
+mv ogvjs-1.6.1 $ASSETS_PATH/ogvjs
+rm -f ogvjs-1.6.1.zip
+
+echo "getting videojs-ogvjs.js"
+curl -L -O https://github.com/hartman/videojs-ogvjs/archive/v1.3.1.zip
+rm -f $ASSETS_PATH/videojs-ogvjs.js
+unzip -o v1.3.1.zip
+mv videojs-ogvjs-1.3.1/dist/videojs-ogvjs.js $ASSETS_PATH/videojs-ogvjs.js
+rm -rf videojs-ogvjs-1.3.1
+rm -f v1.3.1.zip
+
+if command -v fix_ogvjs_dist > /dev/null; then
+    echo "fixing JS files"
+    fix_ogvjs_dist $ASSETS_PATH "assets"
+else
+    echo "NOT fixing JS files (zimscraperlib not installed)"
+fi

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -112,6 +112,13 @@ def main():
         version=SCRAPER,
     )
 
+    parser.add_argument(
+        "--autoplay",
+        help="Enable autoplay on video articles. Behavior differs on platforms/browsers.",
+        action="store_true",
+        default=False,
+    )
+
     args = parser.parse_args()
     logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
 

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -351,7 +351,7 @@ class Ted2Zim:
                 profession=video["speaker_profession"],
                 video_format=self.video_format,
                 autoplay=self.autoplay,
-                video_id=video_id
+                video_id=video_id,
             )
             html_path = self.build_dir.joinpath(f"{video_id}.html")
             with open(html_path, "w", encoding="utf-8") as html_page:

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -484,7 +484,7 @@ class Ted2Zim:
             video_id = str(video["id"])
             video_title = video["title"]
             video_subtitles = video["subtitles"]
-            video_dir = self.build_dir.joinpath(video_id)
+            video_dir = self.videos_dir.joinpath(video_id)
             subs_dir = video_dir.joinpath("subs")
             if not subs_dir.exists():
                 subs_dir.mkdir(parents=True)

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -50,6 +50,7 @@ class Ted2Zim:
         publisher,
         tags,
         keep_build_dir,
+        autoplay,
     ):
 
         # video-encoding info
@@ -72,6 +73,7 @@ class Ted2Zim:
         # scraper options
         self.topics = [c.strip().replace(" ", "+") for c in topics.split(",")]
         self.max_videos_per_topic = max_videos_per_topic
+        self.autoplay = autoplay
 
         # zim info
         self.zim_info = ZimInfo(
@@ -101,6 +103,10 @@ class Ted2Zim:
     @property
     def build_dir(self):
         return self.output_dir.joinpath("build")
+
+    @property
+    def videos_dir(self):
+        return self.build_dir.joinpath("videos")
 
     @property
     def ted_videos_json(self):
@@ -331,9 +337,8 @@ class Ted2Zim:
         )
         for video in self.videos:
             video_id = str(video["id"])
-            video_path = self.build_dir.joinpath(video_id)
-            if not video_path.exists():
-                video_path.mkdir(parents=True)
+            if not self.build_dir.exists():
+                self.build_dir.mkdir(parents=True)
 
             html = env.get_template("article.html").render(
                 title=video["title"],
@@ -345,9 +350,11 @@ class Ted2Zim:
                 date=video["date"],
                 profession=video["speaker_profession"],
                 video_format=self.video_format,
+                autoplay=self.autoplay,
+                video_id=video_id
             )
-            index_path = video_path.joinpath("index.html")
-            with open(index_path, "w", encoding="utf-8") as html_page:
+            html_path = self.build_dir.joinpath(f"{video_id}.html")
+            with open(html_path, "w", encoding="utf-8") as html_page:
                 html_page.write(html)
 
     def render_home_page(self):
@@ -427,7 +434,7 @@ class Ted2Zim:
             video_link = video["video_link"]
             video_speaker = video["speaker_picture"]
             video_thumbnail = video["thumbnail"]
-            video_dir = self.build_dir.joinpath(video_id)
+            video_dir = self.videos_dir.joinpath(video_id)
             video_file_path = video_dir.joinpath("video.mp4")
             speaker_path = video_dir.joinpath("speaker.jpg")
             thumbnail_path = video_dir.joinpath("thumbnail.jpg")

--- a/ted2zim/templates/article.html
+++ b/ted2zim/templates/article.html
@@ -6,21 +6,28 @@
         <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{{ title }}</title>
-        <link href="../assets/videojs/video-js.min.css" rel="stylesheet" type="text/css">
-        <link href="../assets/article.css" rel="stylesheet" type="text/css">
-        <link id="favicon" rel="shortcut icon" href="../favicon.png" type="image/png">
-        <script src="../assets/videojs/video.min.js"></script>
+        <link href="assets/videojs/video-js.min.css" rel="stylesheet" type="text/css">
+        <link href="assets/article.css" rel="stylesheet" type="text/css">
+        <link id="favicon" rel="shortcut icon" href="favicon.png" type="image/png">
+        <script src="assets/zim_prefix.js"></script>
+        <script src="assets/videojs/video.min.js"></script>
+        <script src="assets/ogvjs/ogv-support.js"></script>
+        <script src="assets/ogvjs/ogv.js"></script>
+        <script src="assets/videojs-ogvjs.js"></script>        
     </head>
     <body>
         <div id="content">
-            <img id="backtolist" src="../assets/img/TED_small.png" title="Back to the list" onclick="history.go(-1)" />
+            <img id="backtolist" src="assets/img/TED_small.png" title="Back to the list" onclick="history.go(-1)" />
             <p id="speaker">{{ speaker }}</p>
             <p id="title">{{ title }}</p>
-            <video class="video-js vjs-default-skin" controls preload="auto" width="480px" height="270px"
-                data-setup='{"autoplay": true, "preload": "true"}'>
-                <source src="video.{{ video_format }}" type="video/{{ video_format }}" />
+            <video class="video-js vjs-default-skin"
+                controls preload="auto"
+                poster="videos/{{ video_id }}/thumbnail.jpg"
+                width="480px" height="270px"
+                data-setup='{"techOrder": ["html5", "ogvjs"], "ogvjs": {"base": "assets/ogvjs"}, "autoplay": {% if autoplay %}true{% else %}false{% endif %}, "preload": true, "controls": true, "controlBar": {"pictureInPictureToggle":false}}'>
+                <source src="videos/{{ video_id }}/video.{{ video_format }}" type="video/{{ video_format }}" />
                 {% for language in languages %}
-                    <track kind="subtitles" src="subs/subs_{{ language.languageCode }}.vtt" srclang="{{ language.languageCode }}" label="{{ language.languageName }}" />
+                    <track kind="subtitles" src="videos/{{ video_id }}/subs/subs_{{ language.languageCode }}.vtt" srclang="{{ language.languageCode }}" label="{{ language.languageName }}" />
                     {% endfor %}
                 </video>
                 <div id="description">
@@ -31,7 +38,7 @@
                 <div id="speaker_box_img">
                     <div>
                         {% if speaker_img != "None" %}
-                          <img id="speaker_img" src="speaker.jpg">
+                          <img id="speaker_img" src="videos/{{ video_id }}/speaker.jpg">
                         {% endif %}
                         <div id="speaker_info">
                             <div id="speaker_info_box">{{ speaker }}</div>

--- a/ted2zim/templates/assets/app.js
+++ b/ted2zim/templates/assets/app.js
@@ -125,12 +125,11 @@ function refreshVideos(pageData) {
       var li = document.createElement('li');
       
       var a = document.createElement('a')
-      a.href =  video['id']+'/index.html';
+      a.href =  video['id']+'.html';
       a.className = 'nostyle'
 
       var img = document.createElement('img');
-      /* img.src = video['id']+'/thumbnail.jpg'; */
-      img.src = '../I/'+video['id']+'/thumbnail.jpg'; 
+      img.src = ZIM_IMG_NS+'videos/'+video['id']+'/thumbnail.jpg';
 
       var author = document.createElement('p');
       author.id = 'author';

--- a/ted2zim/templates/assets/zim_prefix.js
+++ b/ted2zim/templates/assets/zim_prefix.js
@@ -1,0 +1,54 @@
+
+/* Generic Zimwriterfs-related properties */
+isInZIM = function() { return document.getElementById("favicon").getAttribute("href").indexOf("/I/") !== -1; }
+IS_IN_ZIM = isInZIM();
+
+getImageNamespacePrefix = function() { return document.getElementById("favicon").getAttribute("href").replace("favicon.png", ""); }
+ZIM_IMG_NS = getImageNamespacePrefix();
+
+getMetaNamespacePrefix = function() { return ZIM_IMG_NS.replace("/I/", "/-/"); }
+ZIM_META_NS = getMetaNamespacePrefix();
+
+hasImageNamespacePrefix = function(target) { return target.indexOf(ZIM_IMG_NS) !== -1;}
+hasMetaNamespacePrefix = function(target) { return target.indexOf(ZIM_META_NS) !== -1;}
+changeNamespacePrefix = function(target, new_ns) {
+    let avail_ns = ["A", "-", "I"];
+    new_ns = new_ns.toUpperCase();
+    if (avail_ns.indexOf(new_ns) == -1) {
+        throw ("Invalid NS: " + new_ns);
+    }
+    let ns_char = -1;
+    avail_ns.forEach(function (namespace) {
+        if (ns_char == -1) {
+            ns_char = target.indexOf("/" + namespace + "/");
+        }
+    });
+    if (ns_char == -1) {
+        // missing prefix
+        return target;
+    }
+
+    return target.slice(0, ns_char + 1) + new_ns + target.slice(ns_char + 2);
+}
+
+/* ogv.js related bits */
+zim_fix_wasm_target = function(target) {
+    console.debug("zim_fix_wasm_target:", target);
+    if (!IS_IN_ZIM) {
+        console.debug("..not in zim");
+        return target;
+    }
+    if (hasImageNamespacePrefix(target)) {
+        // we already have a good path, leave it
+    }
+    else if (hasMetaNamespacePrefix(target)) {
+        // we have a prefix, just replace it
+        target = changeNamespacePrefix(target, "I");
+    }
+    else {
+        // we lack the prefix, add it
+        target = ZIM_IMG_NS + "assets/ogvjs/" + target;
+    }
+    console.debug("..target:", target);
+    return target;
+}

--- a/ted2zim/templates/home.html
+++ b/ted2zim/templates/home.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>TED Talks</title>
     <link id="favicon" rel="shortcut icon" href="favicon.png" type="image/png">
+    <script src="assets/zim_prefix.js"></script>
     <link href="assets/home.css" rel="stylesheet" type="text/css">
     <link href="assets/chosen/chosen.min.css" rel="stylesheet" type="text/css">
   </head>


### PR DESCRIPTION
Fixes #35 - This adds support for latest videojs-ogvjs to play webm files where not natively supported. Also, there are a couple of changes -
- The build directory structure has been changed as follows-
All HTML files are in root of build folder. They are named as <video_id>.html and index.html (for the homepage). The video folders are moved into a common directory called "videos" inside build folder.

- A new argument has been added --autoplay to make videos autoplay on opening the page.