### PR TITLE
S3 based optimization cache for videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Web dependencies removed from repository
 - New Dockerfile
 - New project structure
+- Added S3 based optimization cache support

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ zimscraperlib>=1.0.5,<1.1
 requests>=2.23,<3.0
 beautifulsoup4==4.9.0
 Jinja2==2.10.1
+kiwixstorage>=0.2,<1.0
+pif==0.8.2

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -119,6 +119,19 @@ def main():
         default=False,
     )
 
+    parser.add_argument(
+        "--optimization-cache",
+        help="URL with credentials to S3/S3 based bucket for using as optimization cache",
+        dest="s3_url_with_credentials",
+    )
+
+    parser.add_argument(
+        "--use-any-optimized-version",
+        help="Use the cached files if present, whatever the version",
+        default=False,
+        action="store_true",
+    )
+
     args = parser.parse_args()
     logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
 

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -182,7 +182,7 @@ class Ted2Zim:
         videos = self.soup.select("div.row div.media__image a")
         if len(videos) > video_allowance:
             videos = videos[0:video_allowance]
-        logger.debug(f"{str(len(videos))} videos found on current page")
+        logger.debug(f"{str(len(videos))} video(s) found on current page")
         for video in videos:
             url = urljoin(self.BASE_URL, video["href"])
             self.extract_video_info(url)
@@ -451,9 +451,8 @@ class Ted2Zim:
             thumbnail_path = video_dir.joinpath("thumbnail.jpg")
 
             # ensure that video directory exists and is clean
-            if video_dir.exists():
-                shutil.rmtree(video_dir)
-            video_dir.mkdir(parents=True)
+            if not video_dir.exists():
+                video_dir.mkdir(parents=True)
 
             # download video
             downloaded_from_cache = False
@@ -542,7 +541,7 @@ class Ted2Zim:
             self.topics = json.load(data_file)
 
     def s3_credentials_ok(self):
-        logger.info("testing S3 Optimization Cache credentials")
+        logger.info("Testing S3 Optimization Cache credentials")
         self.s3_storage = KiwixStorage(self.s3_url_with_credentials)
         if not self.s3_storage.check_credentials(
             list_buckets=True, bucket=True, write=True, read=True, failsafe=True
@@ -598,6 +597,12 @@ class Ted2Zim:
             )
         self.extract_all_video_links()
         self.dump_data()
+
+        # clean the build directory if it already exists
+        if self.build_dir.exists():
+            shutil.rmtree(self.build_dir)
+        self.build_dir.mkdir(parents=True)
+
         self.download_video_data()
         self.download_subtitles()
         self.render_home_page()

--- a/ted2zim/templates/assets/db.js
+++ b/ted2zim/templates/assets/db.js
@@ -2,6 +2,8 @@
  * videoDB is responsible for loading
  * and managing the video data from the data.js file.
  */
+
+ /* exported videoDB */
 var videoDB;
 videoDB = (function() {
   var ITEMS_PER_PAGE = 40;


### PR DESCRIPTION
Fixes #20 - This adds S3 based optimization cache for videos. 2 new arguments are added -
- --optimization-cache - S3 URL with credentials
- --use-any-optimized-version - Use any optimized version from any encoder

The key is kept similar to youtube as here also we have unique video IDs but two formats and qualities.