### PR TITLE
Strip subtitle content before convertion

### DIFF
--- a/ted2zim/WebVTTcreator.py
+++ b/ted2zim/WebVTTcreator.py
@@ -48,7 +48,7 @@ class WebVTTcreator:
             for subtitle in json["captions"]:
                 startTime = int(subtitle["startTime"]) + offset
                 duration = int(subtitle["duration"])
-                content = subtitle["content"]
+                content = subtitle["content"].strip()
 
                 self.WebVTTdocument += (
                     self.time_string(startTime)


### PR DESCRIPTION
Fixes #48 by stripping the subtitle content before adding it to VTT file.