### PR TITLE
Audio filtering support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,5 @@
 - New project structure
 - Added S3 based optimization cache support
 - Add support for TED playlists
-- Add support to filter videos available in a specific language
+- Add support to filter videos available in a specific language based on audio and subtitles
+- Add option to choose subtitle languages

--- a/ted2zim/WebVTTcreator.py
+++ b/ted2zim/WebVTTcreator.py
@@ -14,39 +14,40 @@ class WebVTTcreator:
 
     WebVTTdocument = "WEBVTT\n\n"
 
-    def __init__(self, url, offset=0):
+    def __init__(self, url, offset=11820):
+        self.url = url
+        self.offset = offset
 
-        # Loads the json representation of the subtitles form the given
-        # Url and decodes it.
-        # Creates a WebVtt document off it and saves it in a .vtt file.
-        dl_ok = False
-        while not dl_ok:
-            r = requests.get(url)
-            if r.status_code == 429:
-                time.sleep(30)
-            elif r.status_code == 404:
-                return False
-            else:
-                dl_ok = True
-                subtitles_json = r.text
-        if self.is_json(subtitles_json):
-            self.create_WebVtt(json.loads(subtitles_json), offset)
-        else:
+    def time_string(self, ms):
+        """Create the '00:00:00.000' string representation of the time"""
+
+        hours, remainder = divmod(ms, 3600000)
+        minutes, remainder = divmod(remainder, 60000)
+        seconds, miliseconds = divmod(remainder, 1000)
+        return "%.2d:%.2d:%.2d.%.3d" % (hours, minutes, seconds, miliseconds)
+
+    def is_json(self, json_data):
+        try:
+            json.loads(json_data)
+        except ValueError:
             return False
+        return True
 
-    def create_WebVtt(self, json, offset):
+    def create_WebVtt(self, json):
+        """Create the WebVTT file from the given decoded json.
+        Structure of a WebVTT file:
 
-        # Create the WebVTT file from the given decoded json.
-        # Structure of a WebVTT file:
+        WebVTT
 
-        # WebVTT
+        00:00:00.000 --> 00:00:00.000
+        [start time --> end time]
 
-        # 00:00:00.000 --> 00:00:00.000
-        # [start time --> end time]
-        # 'content'
+        'content'
+        """
+
         if "captions" in json:
             for subtitle in json["captions"]:
-                startTime = int(subtitle["startTime"]) + offset
+                startTime = int(subtitle["startTime"]) + self.offset
                 duration = int(subtitle["duration"])
                 content = subtitle["content"].strip()
 
@@ -57,25 +58,22 @@ class WebVTTcreator:
                     + "\n"
                 )
                 self.WebVTTdocument += content + "\n\n"
-
-    def time_string(self, ms):
-
-        # Create the '00:00:00.000' string representation of the time.
-        hours, remainder = divmod(ms, 3600000)
-        minutes, remainder = divmod(remainder, 60000)
-        seconds, miliseconds = divmod(remainder, 1000)
-        return "%.2d:%.2d:%.2d.%.3d" % (hours, minutes, seconds, miliseconds)
-
-    def get_content(self):
         return self.WebVTTdocument
 
-    def is_json(self, json_data):
-        try:
-            json.loads(json_data)
-        except ValueError:
-            return False
-        return True
+    def getVTT(self):
+        """Loads the json representation of the subtitles form the given URL and decodes it, and returns its WebVTT representation"""
 
-
-if __name__ == "__main__":
-    WebVTTcreator("https://www.ted.com/talks/subtitles/id/1907/lang/en")
+        dl_ok = False
+        while not dl_ok:
+            r = requests.get(self.url)
+            if r.status_code == 429:
+                time.sleep(30)
+            elif r.status_code == 404:
+                return
+            else:
+                dl_ok = True
+                subtitles_json = r.text
+        if self.is_json(subtitles_json):
+            return self.create_WebVtt(json.loads(subtitles_json))
+        else:
+            return

--- a/ted2zim/WebVTTcreator.py
+++ b/ted2zim/WebVTTcreator.py
@@ -69,11 +69,10 @@ class WebVTTcreator:
             if r.status_code == 429:
                 time.sleep(30)
             elif r.status_code == 404:
-                return
+                return None
             else:
                 dl_ok = True
                 subtitles_json = r.text
         if self.is_json(subtitles_json):
             return self.create_WebVtt(json.loads(subtitles_json))
-        else:
-            return
+        return None

--- a/ted2zim/constants.py
+++ b/ted2zim/constants.py
@@ -20,3 +20,7 @@ SCRAPER = f"{NAME} {VERSION}"
 BASE_URL = "https://ted.com/"
 
 logger = getLogger(NAME, level=logging.DEBUG)
+
+MATCHING = "matching"
+ALL = "all"
+NONE = "none"

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -5,7 +5,7 @@
 import logging
 import argparse
 
-from .constants import NAME, SCRAPER, LANG, ALL, NONE, logger
+from .constants import NAME, SCRAPER, MATCHING, ALL, NONE, logger
 from .scraper import Ted2Zim
 
 
@@ -151,9 +151,8 @@ def main():
     parser.add_argument(
         "--subtitles",
         help="Whether to provide subtitles in language requested, no subtitles, or all available subtitles",
-        default=LANG,
+        default=MATCHING,
         dest="subtitles_setting",
-        choices=[LANG, ALL, NONE],
     )
 
     args = parser.parse_args()

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -5,7 +5,7 @@
 import logging
 import argparse
 
-from .constants import NAME, SCRAPER, logger
+from .constants import NAME, SCRAPER, LANG, ALL, NONE, logger
 from .scraper import Ted2Zim
 
 
@@ -139,6 +139,21 @@ def main():
         "--only-videos-in",
         help="An ISO-639-1 language code with two letter country code where relevant to get videos in that specific language. Subtitle availablity is considered if audio is not found in that language",
         dest="source_language",
+    )
+
+    parser.add_argument(
+        "--subtitles-enough",
+        help="Consider subtitle availability while filtering videos by language",
+        default=False,
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "--subtitles",
+        help="Whether to provide subtitles in language requested, no subtitles, or all available subtitles",
+        default=LANG,
+        dest="subtitles_setting",
+        choices=[LANG, ALL, NONE],
     )
 
     args = parser.parse_args()

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -137,7 +137,7 @@ def main():
 
     parser.add_argument(
         "--only-videos-in",
-        help="An ISO-639-1 language code with two letter country code where relevant to get videos in that specific language. Subtitle availablity is considered if audio is not found in that language",
+        help="Comma-seperated list of TED language codes",
         dest="source_language",
     )
 
@@ -166,13 +166,21 @@ def main():
                 parser.error(
                     "Maximum number of videos to scrape per topic must be greater than or equal to 1"
                 )
+            if args.subtitles_enough and not args.source_language:
+                parser.error(
+                    "--subtitles-enough is only meant to be used if --only-videos-in is present"
+                )
         elif args.playlist:
             if args.source_language:
                 parser.error(
                     "--only-videos-in is not compatible with playlists. Use this option only in combination with --topics"
                 )
+            if args.subtitles_enough:
+                parser.error("--subtitles-enough is not compatible with playlists")
         else:
             parser.error("Either --topics or --playlist is required")
+        if not args.subtitles_setting:
+            parser.error("--subtitles cannot take in empty string")
         scraper = Ted2Zim(**dict(args._get_kwargs()))
         scraper.run()
     except Exception as exc:

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -143,14 +143,14 @@ def main():
 
     parser.add_argument(
         "--subtitles-enough",
-        help="Consider subtitle availability while filtering videos by language",
+        help="Whether to include videos that have a subtitle in requested --language if audio in another language",
         default=False,
         action="store_true",
     )
 
     parser.add_argument(
         "--subtitles",
-        help="Whether to provide subtitles in language requested, no subtitles, or all available subtitles",
+        help="Language setting for subtitles. ALL: include all available subtitles, MATCHING (default): only subtitles matching --language, NONE: include no subtitle. Apart from this, also accepts comma-seperated list of language codes",
         default=MATCHING,
         dest="subtitles_setting",
     )

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -466,7 +466,7 @@ class Ted2Zim:
                         {"lang": "default", "text": video["description"][idx]["text"]}
                     ] + video["description"]
                     break
-            if en_found == False:
+            if not en_found:
                 video["title"] = [
                     {"lang": "default", "text": video["title"][0]["text"]}
                 ] + video["title"]

--- a/ted2zim/templates/article.html
+++ b/ted2zim/templates/article.html
@@ -14,7 +14,6 @@
         <script src="assets/ogvjs/ogv-support.js"></script>
         <script src="assets/ogvjs/ogv.js"></script>
         <script src="assets/videojs-ogvjs.js"></script>
-        <script src="assets/data.js"></script>
         <script src="assets/jquery.min.js"></script>
         <script src="assets/article.js"></script>        
     </head>
@@ -22,19 +21,23 @@
         <div id="content">
             <img id="backtolist" src="assets/img/TED_small.png" title="Back to the list" onclick="history.go(-1)" />
             <p id="speaker">{{ speaker }}</p>
-            <p id="title-text"></p>
+            {% for title in titles %}
+            <p class="title lang-{{ title.lang }}">{{ title.text }}</p>
+            {% endfor %}
             <video class="video-js vjs-default-skin"
                 controls preload="auto"
                 poster="videos/{{ video_id }}/thumbnail.jpg"
                 width="480px" height="270px"
                 data-setup='{"techOrder": ["html5", "ogvjs"], "ogvjs": {"base": "assets/ogvjs"}, "autoplay": {% if autoplay %}true{% else %}false{% endif %}, "preload": true, "controls": true, "controlBar": {"pictureInPictureToggle":false}}'>
                 <source src="videos/{{ video_id }}/video.{{ video_format }}" type="video/{{ video_format }}" />
-                {% for language in languages %}
+                    {% for language in languages %}
                     <track kind="subtitles" src="videos/{{ video_id }}/subs/subs_{{ language.languageCode }}.vtt" srclang="{{ language.languageCode }}" label="{{ language.languageName }}" />
                     {% endfor %}
                 </video>
-                <div id="description">
-                    <p id="description-text"></p>
+                <div id="descriptions">
+                    {% for description in descriptions %}
+                    <p class="description lang-{{ description.lang }}">{{ description.text }}</p>
+                    {% endfor %}
                 </div>
                 <div id="date">{{ date }}</div>
                 <hr>

--- a/ted2zim/templates/article.html
+++ b/ted2zim/templates/article.html
@@ -5,7 +5,7 @@
         <meta content="utf-8" http-equiv="encoding">
         <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>{{ title }}</title>
+        <title id="title-head"></title>
         <link href="assets/videojs/video-js.min.css" rel="stylesheet" type="text/css">
         <link href="assets/article.css" rel="stylesheet" type="text/css">
         <link id="favicon" rel="shortcut icon" href="favicon.png" type="image/png">
@@ -13,13 +13,16 @@
         <script src="assets/videojs/video.min.js"></script>
         <script src="assets/ogvjs/ogv-support.js"></script>
         <script src="assets/ogvjs/ogv.js"></script>
-        <script src="assets/videojs-ogvjs.js"></script>        
+        <script src="assets/videojs-ogvjs.js"></script>
+        <script src="assets/data.js"></script>
+        <script src="assets/jquery.min.js"></script>
+        <script src="assets/article.js"></script>        
     </head>
     <body>
         <div id="content">
             <img id="backtolist" src="assets/img/TED_small.png" title="Back to the list" onclick="history.go(-1)" />
             <p id="speaker">{{ speaker }}</p>
-            <p id="title">{{ title }}</p>
+            <p id="title-text"></p>
             <video class="video-js vjs-default-skin"
                 controls preload="auto"
                 poster="videos/{{ video_id }}/thumbnail.jpg"
@@ -31,7 +34,7 @@
                     {% endfor %}
                 </video>
                 <div id="description">
-                    <p id="description">{{ description }}</p>
+                    <p id="description-text"></p>
                 </div>
                 <div id="date">{{ date }}</div>
                 <hr>

--- a/ted2zim/templates/assets/app.js
+++ b/ted2zim/templates/assets/app.js
@@ -7,7 +7,7 @@ window.onload = function() {
   // This will display all data without any language filter.
   videoDB.loadData(undefined, function() {
     var data = videoDB.getPage(videoDB.getPageNumber());
-    refreshVideos(data);
+    refreshVideos(undefined, data);
   });
 
   refreshPagination();
@@ -36,7 +36,7 @@ function setupLanguageFilter() {
     videoDB.resetPage();
     videoDB.loadData(language, function() {
       var data = videoDB.getPage(videoDB.getPageNumber());
-      refreshVideos(data);
+      refreshVideos(language, data);
       refreshPagination();
     });
   });
@@ -50,7 +50,7 @@ function setupPagination() {
 
     function handlePagination(){
 	var data = videoDB.getPage(videoDB.getPageNumber());
-	refreshVideos(data);
+	refreshVideos(undefined, data);
 	refreshPagination();
 	window.scrollTo(0, 0);
     }
@@ -115,16 +115,21 @@ function refreshPagination() {
  * the passed in {pageData} parameter.
  * @param {pageData} Video data for the current page.
  */
-function refreshVideos(pageData) {  
+function refreshVideos(language, pageData) {  
     var videoList = document.getElementById('video-items');
     videoList.innerHTML = '';
-    
     for (i in pageData) {
       var video = pageData[i];
+      idx = 0;
+      for (j in video.title) {
+        if (video.title[j].lang == language) {
+          idx = j;
+        }
+      }
       var li = document.createElement('li');
       
       var a = document.createElement('a')
-      a.href =  video['id']+'.html';
+      a.href =  video['id']+'.html?lang=' + language;
       a.className = 'nostyle'
 
       var img = document.createElement('img');
@@ -136,7 +141,7 @@ function refreshVideos(pageData) {
       
       var title = document.createElement('p');
       title.id = 'title';
-      title.innerHTML = video['title'];
+      title.innerHTML = video['title'][idx].text;
 
       a.appendChild(img);
       a.appendChild(author);

--- a/ted2zim/templates/assets/app.js
+++ b/ted2zim/templates/assets/app.js
@@ -115,21 +115,23 @@ function refreshPagination() {
  * the passed in {pageData} parameter.
  * @param {pageData} Video data for the current page.
  */
-function refreshVideos(language, pageData) {  
+function refreshVideos(language, pageData) {
     var videoList = document.getElementById('video-items');
     videoList.innerHTML = '';
     for (i in pageData) {
       var video = pageData[i];
+      var lang = undefined;
       idx = 0;
       for (j in video.title) {
         if (video.title[j].lang == language) {
           idx = j;
+          lang = language;
         }
       }
       var li = document.createElement('li');
       
       var a = document.createElement('a')
-      a.href =  video['id']+'.html?lang=' + language;
+      a.href =  video['id']+'.html?lang=' + lang;
       a.className = 'nostyle'
 
       var img = document.createElement('img');

--- a/ted2zim/templates/assets/article.css
+++ b/ted2zim/templates/assets/article.css
@@ -45,7 +45,7 @@ hr {
     max-width:100%;
 }
 
-#description-text {
+.description {
     font-family: 'RobotoLight';
     color: #333;
     width: 480px;
@@ -53,6 +53,11 @@ hr {
     text-align: justify;
     text-justify: inter-word;
     max-width:100%;
+    display: none;
+}
+
+.description.lang-default {
+    display: block;
 }
 
 #speaker {
@@ -62,13 +67,18 @@ hr {
     max-width:100%;
 }
 
-#title-text {
+.title {
     font-family: "RobotoBold";
     margin-top: 10px;
     font-size: 30px;
     text-align: left;
     text-justify: none;
     max-width:100%;
+    display: none;
+}
+
+.title.lang-default {
+    display: block;
 }
 
 #views {

--- a/ted2zim/templates/assets/article.css
+++ b/ted2zim/templates/assets/article.css
@@ -45,7 +45,7 @@ hr {
     max-width:100%;
 }
 
-#description {
+#description-text {
     font-family: 'RobotoLight';
     color: #333;
     width: 480px;
@@ -62,7 +62,7 @@ hr {
     max-width:100%;
 }
 
-#title {
+#title-text {
     font-family: "RobotoBold";
     margin-top: 10px;
     font-size: 30px;

--- a/ted2zim/templates/assets/article.js
+++ b/ted2zim/templates/assets/article.js
@@ -1,0 +1,25 @@
+$.urlParam = function(name){
+    var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(window.location.href);
+    if (results==null) {
+       return null;
+    }
+    return decodeURI(results[1]) || 0;
+}
+
+window.onload = function() {
+    html_name = window.location.pathname.substring(window.location.pathname.lastIndexOf("/") + 1);
+    video_id = html_name.substring(0, html_name.lastIndexOf("."));
+    for (i in json_data) {
+        if(json_data[i].id == video_id){
+            var idx = 0;
+            for (j in json_data[i].title) {
+                if (json_data[i].title[j].lang == $.urlParam('lang')) {
+                idx = j;
+                }
+            }
+            document.getElementById("title-head").innerHTML = json_data[i].title[idx].text;
+            document.getElementById("description-text").innerHTML = json_data[i].description[idx].text;
+            document.getElementById("title-text").innerHTML = json_data[i].title[idx].text;
+        }
+    }
+};

--- a/ted2zim/templates/assets/article.js
+++ b/ted2zim/templates/assets/article.js
@@ -4,23 +4,16 @@ $.urlParam = function(name){
        return null;
     }
     return decodeURI(results[1]) || 0;
-}
+};
 
 window.onload = function() {
-    requested_language = $.urlParam('lang')
-    html_name = window.location.pathname.substring(window.location.pathname.lastIndexOf("/") + 1);
-    video_id = html_name.substring(0, html_name.lastIndexOf("."));
-    for (i in json_data) {
-        if(json_data[i].id == video_id){
-            var idx = 0;
-            for (j in json_data[i].title) {
-                if (json_data[i].title[j].lang == requested_language) {
-                idx = j;
-                }
-            }
-            document.getElementById("title-head").innerHTML = json_data[i].title[idx].text;
-            document.getElementById("description-text").innerHTML = json_data[i].description[idx].text;
-            document.getElementById("title-text").innerHTML = json_data[i].title[idx].text;
-        }
+    let lang = $.urlParam('lang');
+    if (lang === "undefined") {
+        document.getElementById("title-head").innerHTML = $("p.title.lang-default").text();
+    }
+    else {
+        document.getElementById("title-head").innerHTML = $("p.title.lang-" + lang).text();
+        $(".lang-default").css("display", "none");
+        $(".lang-" + lang).css("display", "block");
     }
 };

--- a/ted2zim/templates/assets/article.js
+++ b/ted2zim/templates/assets/article.js
@@ -1,5 +1,5 @@
 $.urlParam = function(name){
-    var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(window.location.href);
+    var results = new RegExp('[?&]' + name + '=([^&#]*)').exec(window.location.href);
     if (results==null) {
        return null;
     }

--- a/ted2zim/templates/assets/article.js
+++ b/ted2zim/templates/assets/article.js
@@ -7,13 +7,14 @@ $.urlParam = function(name){
 }
 
 window.onload = function() {
+    requested_language = $.urlParam('lang')
     html_name = window.location.pathname.substring(window.location.pathname.lastIndexOf("/") + 1);
     video_id = html_name.substring(0, html_name.lastIndexOf("."));
     for (i in json_data) {
         if(json_data[i].id == video_id){
             var idx = 0;
             for (j in json_data[i].title) {
-                if (json_data[i].title[j].lang == $.urlParam('lang')) {
+                if (json_data[i].title[j].lang == requested_language) {
                 idx = j;
                 }
             }

--- a/ted2zim/templates/assets/db.js
+++ b/ted2zim/templates/assets/db.js
@@ -26,14 +26,24 @@ videoDB = (function() {
   db.loadData = function(language, callback){
     // Clear the previously loaded data.
     data = [];
+    tempObj = {
+      "title" : "undefined",
+      "description" : "undefined",
+      "id" : "undefined",
+      "languages" : "undefined",
+      "speaker" : "undefined"
+    }
     if (typeof language === 'undefined'){
       for (i in json_data){
-        var tempObj = json_data[i];
-        tempObj.title = json_data[i].title[0].text;
         tempObj.description = json_data[i].description[0].text;
+        tempObj.title = json_data[i].title[0].text;
+        tempObj.id = json_data[i].id;
+        tempObj.languages = json_data[i].languages;
+        tempObj.speaker = json_data[i].speaker;
         data.push(tempObj);
       }
     }
+    
     else {
 
       // Iterate through the whole data set and 
@@ -47,9 +57,11 @@ videoDB = (function() {
               idx = j;
             }
           }
-          var tempObj = json_data[i]
-          tempObj.title = json_data[i].title[idx].text;
           tempObj.description = json_data[i].description[idx].text;
+          tempObj.title = json_data[i].title[idx].text;
+          tempObj.id = json_data[i].id;
+          tempObj.languages = json_data[i].languages;
+          tempObj.speaker = json_data[i].speaker;
           data.push(tempObj);
         }
       }

--- a/ted2zim/templates/assets/db.js
+++ b/ted2zim/templates/assets/db.js
@@ -4,134 +4,109 @@
  */
 
  /* exported videoDB */
-var videoDB;
-videoDB = (function() {
-  var ITEMS_PER_PAGE = 40;
-  var db = {};
-  var data;
-  var page;
-
-  /**
-   * Load the data with or without an 
-   * applied language filter. 
-   * The data will be loaded from the json in 
-   * the data.js file.
-   * @param {language} Language filter that you want
-   *                   to apply to the data set. 
-   *                   Pass in 'undefined' if you don't 
-   *                   want any language filter.
-   * @param {callback} This callback will be called 
-   *                   when the data is loaded.
-   */
-  db.loadData = function(language, callback){
-    // Clear the previously loaded data.
-    data = [];
-    tempObj = {
-      "title" : "undefined",
-      "description" : "undefined",
-      "id" : "undefined",
-      "languages" : "undefined",
-      "speaker" : "undefined"
-    }
-    if (typeof language === 'undefined'){
-      for (i in json_data){
-        tempObj.description = json_data[i].description[0].text;
-        tempObj.title = json_data[i].title[0].text;
-        tempObj.id = json_data[i].id;
-        tempObj.languages = json_data[i].languages;
-        tempObj.speaker = json_data[i].speaker;
-        data.push(tempObj);
-      }
-    }
-    
-    else {
-
-      // Iterate through the whole data set and 
-      // add the video objects that have the language 
-      // that we want to the data array.
-      for (i in json_data){
-        if (json_data[i].languages.indexOf(language) > -1) {
-          var idx = 0;
-          for (j in json_data[i].title) {
-            if (json_data[i].title[j].lang == language) {
-              idx = j;
-            }
-          }
-          tempObj.description = json_data[i].description[idx].text;
-          tempObj.title = json_data[i].title[idx].text;
-          tempObj.id = json_data[i].id;
-          tempObj.languages = json_data[i].languages;
-          tempObj.speaker = json_data[i].speaker;
-          data.push(tempObj);
-        }
-      }
-    }
-    callback();
-  }
-
-  /**
-   * Get the count pages that we need to set up.
-   */
-  db.getPageCount = function() {
-    return Math.ceil(data.length / ITEMS_PER_PAGE);
-  }
-
-  /**
-   * Move one page forward. 
-   * @param {callback} This callback is called when 
-   *                   you have to load a new page. 
-   */
-  db.pageForward = function(callback) {
-    if (page < db.getPageCount()) {
-      page++;
-      window.location.hash = '#' + page;  
-      callback();
-    }
-  }
-
-  /**
-   * Move one page back. 
-   * @param {callback} This callback is called when 
-   *                   you have to load a new page. 
-   */
-  db.pageBackwards = function(callback) {
-    if (page != 1) {
-      page--;
-      window.location.hash = '#' + page;
-      callback();
-    }
-  }
-
-  /**
-   * Reset the page count to 1.
-   */
-  db.resetPage = function() {
-    page = 1;
-    window.location.hash = '#' + page;
-  }
-
-  /**
-   * Get the current page number.
-   */
-  db.getPageNumber = function() {
-      if ( !page ) {
-	  page = location.hash.replace( '#', '' );
-      }
-
-      return page || 1;
-  }
-
-  /**
-   * Get the video data for a certain page.
-   * @param {page} Page number for the page 
-   *               you want the data for.
-   */
-  db.getPage = function(page) {
-    var pageStart = (page-1)*ITEMS_PER_PAGE;
-    var pageEnd = page*ITEMS_PER_PAGE;
-    return data.slice(pageStart, pageEnd);
-  }
-
-  return db;
-
-}());
+ var videoDB;
+ videoDB = (function() {
+   var ITEMS_PER_PAGE = 40;
+   var db = {};
+   var data;
+   var page;
+ 
+   /**
+    * Load the data with or without an 
+    * applied language filter. 
+    * The data will be loaded from the json in 
+    * the data.js file.
+    * @param {language} Language filter that you want
+    *                   to apply to the data set. 
+    *                   Pass in 'undefined' if you don't 
+    *                   want any language filter.
+    * @param {callback} This callback will be called 
+    *                   when the data is loaded.
+    */
+   db.loadData = function(language, callback){
+     if (typeof language === 'undefined'){
+       data = json_data;
+     }
+     else {
+ 
+       // Clear the previously loaded data.
+       data = [];
+ 
+       // Iterate through the whole data set and 
+       // add the video objects that have the language 
+       // that we want to the data array.
+       for (i in json_data){
+         if (json_data[i].languages.indexOf(language) > -1) {
+           data.push(json_data[i]);
+         }
+       }
+     }
+     callback();
+   }
+ 
+   /**
+    * Get the count pages that we need to set up.
+    */
+   db.getPageCount = function() {
+     return Math.ceil(data.length / ITEMS_PER_PAGE);
+   }
+ 
+   /**
+    * Move one page forward. 
+    * @param {callback} This callback is called when 
+    *                   you have to load a new page. 
+    */
+   db.pageForward = function(callback) {
+     if (page < db.getPageCount()) {
+       page++;
+       window.location.hash = '#' + page;  
+       callback();
+     }
+   }
+ 
+   /**
+    * Move one page back. 
+    * @param {callback} This callback is called when 
+    *                   you have to load a new page. 
+    */
+   db.pageBackwards = function(callback) {
+     if (page != 1) {
+       page--;
+       window.location.hash = '#' + page;
+       callback();
+     }
+   }
+ 
+   /**
+    * Reset the page count to 1.
+    */
+   db.resetPage = function() {
+     page = 1;
+     window.location.hash = '#' + page;
+   }
+ 
+   /**
+    * Get the current page number.
+    */
+   db.getPageNumber = function() {
+       if ( !page ) {
+     page = location.hash.replace( '#', '' );
+       }
+ 
+       return page || 1;
+   }
+ 
+   /**
+    * Get the video data for a certain page.
+    * @param {page} Page number for the page 
+    *               you want the data for.
+    */
+   db.getPage = function(page) {
+     var pageStart = (page-1)*ITEMS_PER_PAGE;
+     var pageEnd = page*ITEMS_PER_PAGE;
+     return data.slice(pageStart, pageEnd);
+   }
+ 
+   return db;
+ 
+ }());

--- a/ted2zim/templates/assets/db.js
+++ b/ted2zim/templates/assets/db.js
@@ -1,9 +1,9 @@
 /**
-* videoDB is responsible for loading
-* and managing the video data from the data.js file.
-*/
+ * videoDB is responsible for loading
+ * and managing the video data from the data.js file.
+ */
 
-/* exported videoDB */
+ /* exported videoDB */
 var videoDB;
 videoDB = (function() {
   var ITEMS_PER_PAGE = 40;
@@ -90,7 +90,7 @@ videoDB = (function() {
    */
   db.getPageNumber = function() {
       if ( !page ) {
-    page = location.hash.replace( '#', '' );
+	  page = location.hash.replace( '#', '' );
       }
 
       return page || 1;

--- a/ted2zim/templates/assets/db.js
+++ b/ted2zim/templates/assets/db.js
@@ -24,20 +24,33 @@ videoDB = (function() {
    *                   when the data is loaded.
    */
   db.loadData = function(language, callback){
+    // Clear the previously loaded data.
+    data = [];
     if (typeof language === 'undefined'){
-      data = json_data;
+      for (i in json_data){
+        var tempObj = json_data[i];
+        tempObj.title = json_data[i].title[0].text;
+        tempObj.description = json_data[i].description[0].text;
+        data.push(tempObj);
+      }
     }
     else {
-
-      // Clear the previously loaded data.
-      data = [];
 
       // Iterate through the whole data set and 
       // add the video objects that have the language 
       // that we want to the data array.
       for (i in json_data){
         if (json_data[i].languages.indexOf(language) > -1) {
-          data.push(json_data[i]);
+          var idx = 0;
+          for (j in json_data[i].title) {
+            if (json_data[i].title[j].lang == language) {
+              idx = j;
+            }
+          }
+          var tempObj = json_data[i]
+          tempObj.title = json_data[i].title[idx].text;
+          tempObj.description = json_data[i].description[idx].text;
+          data.push(tempObj);
         }
       }
     }

--- a/ted2zim/templates/assets/db.js
+++ b/ted2zim/templates/assets/db.js
@@ -1,112 +1,112 @@
 /**
- * videoDB is responsible for loading
- * and managing the video data from the data.js file.
- */
+* videoDB is responsible for loading
+* and managing the video data from the data.js file.
+*/
 
- /* exported videoDB */
- var videoDB;
- videoDB = (function() {
-   var ITEMS_PER_PAGE = 40;
-   var db = {};
-   var data;
-   var page;
- 
-   /**
-    * Load the data with or without an 
-    * applied language filter. 
-    * The data will be loaded from the json in 
-    * the data.js file.
-    * @param {language} Language filter that you want
-    *                   to apply to the data set. 
-    *                   Pass in 'undefined' if you don't 
-    *                   want any language filter.
-    * @param {callback} This callback will be called 
-    *                   when the data is loaded.
-    */
-   db.loadData = function(language, callback){
-     if (typeof language === 'undefined'){
-       data = json_data;
-     }
-     else {
- 
-       // Clear the previously loaded data.
-       data = [];
- 
-       // Iterate through the whole data set and 
-       // add the video objects that have the language 
-       // that we want to the data array.
-       for (i in json_data){
-         if (json_data[i].languages.indexOf(language) > -1) {
-           data.push(json_data[i]);
-         }
-       }
-     }
-     callback();
-   }
- 
-   /**
-    * Get the count pages that we need to set up.
-    */
-   db.getPageCount = function() {
-     return Math.ceil(data.length / ITEMS_PER_PAGE);
-   }
- 
-   /**
-    * Move one page forward. 
-    * @param {callback} This callback is called when 
-    *                   you have to load a new page. 
-    */
-   db.pageForward = function(callback) {
-     if (page < db.getPageCount()) {
-       page++;
-       window.location.hash = '#' + page;  
-       callback();
-     }
-   }
- 
-   /**
-    * Move one page back. 
-    * @param {callback} This callback is called when 
-    *                   you have to load a new page. 
-    */
-   db.pageBackwards = function(callback) {
-     if (page != 1) {
-       page--;
-       window.location.hash = '#' + page;
-       callback();
-     }
-   }
- 
-   /**
-    * Reset the page count to 1.
-    */
-   db.resetPage = function() {
-     page = 1;
-     window.location.hash = '#' + page;
-   }
- 
-   /**
-    * Get the current page number.
-    */
-   db.getPageNumber = function() {
-       if ( !page ) {
-     page = location.hash.replace( '#', '' );
-       }
- 
-       return page || 1;
-   }
- 
-   /**
-    * Get the video data for a certain page.
-    * @param {page} Page number for the page 
-    *               you want the data for.
-    */
-   db.getPage = function(page) {
-     var pageStart = (page-1)*ITEMS_PER_PAGE;
-     var pageEnd = page*ITEMS_PER_PAGE;
-     return data.slice(pageStart, pageEnd);
-   }
- 
-   return db;
- 
- }());
+/* exported videoDB */
+var videoDB;
+videoDB = (function() {
+  var ITEMS_PER_PAGE = 40;
+  var db = {};
+  var data;
+  var page;
+
+  /**
+   * Load the data with or without an 
+   * applied language filter. 
+   * The data will be loaded from the json in 
+   * the data.js file.
+   * @param {language} Language filter that you want
+   *                   to apply to the data set. 
+   *                   Pass in 'undefined' if you don't 
+   *                   want any language filter.
+   * @param {callback} This callback will be called 
+   *                   when the data is loaded.
+   */
+  db.loadData = function(language, callback){
+    if (typeof language === 'undefined'){
+      data = json_data;
+    }
+    else {
+
+      // Clear the previously loaded data.
+      data = [];
+
+      // Iterate through the whole data set and 
+      // add the video objects that have the language 
+      // that we want to the data array.
+      for (i in json_data){
+        if (json_data[i].languages.indexOf(language) > -1) {
+          data.push(json_data[i]);
+        }
+      }
+    }
+    callback();
+  }
+
+  /**
+   * Get the count pages that we need to set up.
+   */
+  db.getPageCount = function() {
+    return Math.ceil(data.length / ITEMS_PER_PAGE);
+  }
+
+  /**
+   * Move one page forward. 
+   * @param {callback} This callback is called when 
+   *                   you have to load a new page. 
+   */
+  db.pageForward = function(callback) {
+    if (page < db.getPageCount()) {
+      page++;
+      window.location.hash = '#' + page;  
+      callback();
+    }
+  }
+
+  /**
+   * Move one page back. 
+   * @param {callback} This callback is called when 
+   *                   you have to load a new page. 
+   */
+  db.pageBackwards = function(callback) {
+    if (page != 1) {
+      page--;
+      window.location.hash = '#' + page;
+      callback();
+    }
+  }
+
+  /**
+   * Reset the page count to 1.
+   */
+  db.resetPage = function() {
+    page = 1;
+    window.location.hash = '#' + page;
+  }
+
+  /**
+   * Get the current page number.
+   */
+  db.getPageNumber = function() {
+      if ( !page ) {
+    page = location.hash.replace( '#', '' );
+      }
+
+      return page || 1;
+  }
+
+  /**
+   * Get the video data for a certain page.
+   * @param {page} Page number for the page 
+   *               you want the data for.
+   */
+  db.getPage = function(page) {
+    var pageStart = (page-1)*ITEMS_PER_PAGE;
+    var pageEnd = page*ITEMS_PER_PAGE;
+    return data.slice(pageStart, pageEnd);
+  }
+
+  return db;
+
+}());


### PR DESCRIPTION
This will fix #57 and #53 by adding support for language filtering based on both audio and subtitle languages.

Two new parameters are introduced -
- --subtitles-enough - This is a boolean flag that enables the ability to consider subtitle language.
- --subtitle - This one handles subtitles. It has 4 options, `all`, `matching`(default - matches with the languages provided to --only-videos-in), `none` and passing exact language codes.
If no language is provided to --only-videos-in and subtitles is automatically set to `all` . Similarly, if --subtitles-enough is passed and --subtitles=none is passed, --subtitles is automatically ignored and changed to `matching`

Current status - Working. However, some code improvements and simplification is needed.