### PR TITLE
Combine --language and --only-videos-in args

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil==2.8.1
-zimscraperlib>=1.0.5,<1.1
+zimscraperlib>=1.1.0,<1.2
 requests>=2.23,<3.0
 beautifulsoup4==4.9.0
 Jinja2==2.10.1

--- a/ted2zim/constants.py
+++ b/ted2zim/constants.py
@@ -24,3 +24,8 @@ logger = getLogger(NAME, level=logging.DEBUG)
 MATCHING = "matching"
 ALL = "all"
 NONE = "none"
+
+TEDLANGS = {
+    "locales": ["zh-cn", "zh-tw", "pt-br", "fr-ca"],
+    "mappings": {"zh": ["zh-cn", "zh-tw"], "pt": ["pt-br"], "fr": ["fr-ca"],},
+}

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -68,7 +68,7 @@ def main():
     )
 
     parser.add_argument(
-        "--language", help="Comma-seperated list of languages to filter videos"
+        "--languages", help="Comma-seperated list of languages to filter videos"
     )
 
     parser.add_argument(
@@ -137,14 +137,14 @@ def main():
 
     parser.add_argument(
         "--subtitles-enough",
-        help="Whether to include videos that have a subtitle in requested --language if audio in another language",
+        help="Whether to include videos that have a subtitle in requested --languages if audio in another language",
         default=False,
         action="store_true",
     )
 
     parser.add_argument(
         "--subtitles",
-        help="Language setting for subtitles. ALL: include all available subtitles, MATCHING (default): only subtitles matching --language, NONE: include no subtitle. Apart from this, also accepts comma-seperated list of language codes",
+        help="Language setting for subtitles. ALL: include all available subtitles, MATCHING (default): only subtitles matching --languages, NONE: include no subtitle. Apart from this, also accepts comma-seperated list of language codes",
         default=MATCHING,
         dest="subtitles_setting",
     )
@@ -160,9 +160,9 @@ def main():
                 parser.error(
                     "Maximum number of videos to scrape per topic must be greater than or equal to 1"
                 )
-            if args.subtitles_enough and not args.language:
+            if args.subtitles_enough and not args.languages:
                 parser.error(
-                    "--subtitles-enough is only meant to be used if --language is present"
+                    "--subtitles-enough is only meant to be used if --languages is present"
                 )
         elif args.playlist:
             if args.subtitles_enough:

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -68,7 +68,7 @@ def main():
     )
 
     parser.add_argument(
-        "--language", help="ISO-639-3 (3 chars) language code of content", default="eng"
+        "--language", help="Comma-seperated list of languages to filter videos"
     )
 
     parser.add_argument(
@@ -136,12 +136,6 @@ def main():
     )
 
     parser.add_argument(
-        "--only-videos-in",
-        help="Comma-seperated list of TED language codes",
-        dest="source_language",
-    )
-
-    parser.add_argument(
         "--subtitles-enough",
         help="Whether to include videos that have a subtitle in requested --language if audio in another language",
         default=False,
@@ -166,15 +160,11 @@ def main():
                 parser.error(
                     "Maximum number of videos to scrape per topic must be greater than or equal to 1"
                 )
-            if args.subtitles_enough and not args.source_language:
+            if args.subtitles_enough and not args.language:
                 parser.error(
-                    "--subtitles-enough is only meant to be used if --only-videos-in is present"
+                    "--subtitles-enough is only meant to be used if --language is present"
                 )
         elif args.playlist:
-            if args.source_language:
-                parser.error(
-                    "--only-videos-in is not compatible with playlists. Use this option only in combination with --topics"
-                )
             if args.subtitles_enough:
                 parser.error("--subtitles-enough is not compatible with playlists")
         else:

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -327,63 +327,47 @@ class Ted2Zim:
         else:
             return lang_name
 
-    def generate_subtitle_list(self, video_id, langs, current_lang):
-        """Generate a list of all subtitle languages with the link to its subtitles page. 
+    def get_subtitle_dict(self, lang):
+        """ returns a dict of language name and code from a larger dict lang 
 
         It will be in this format:
-        [
-            {
-                'languageCode': 'en',
-                'link': 'https://www.ted.com/talks/subtitles/id/1907/lang/en',
-                'languageName': 'English'
-            }
-        ]
+        {
+            'languageCode': 'en',
+            'languageName': 'English'
+        }
         """
+
+        return {
+            "languageName": self.lang_display_string(
+                lang["languageCode"], lang["languageName"]
+            ),
+            "languageCode": lang["languageCode"],
+        }
+
+    def generate_subtitle_list(self, video_id, langs, current_lang):
+        """ Generate a list of all subtitle languages with the link to its subtitles page """
 
         subtitles = []
         if self.subtitles_setting == ALL or (not self.source_language and self.topics):
-            subtitles = [
-                {
-                    "languageName": self.lang_display_string(
-                        lang["languageCode"], lang["languageName"]
-                    ),
-                    "languageCode": lang["languageCode"],
-                }
-                for lang in langs
-            ]
+            subtitles = [self.get_subtitle_dict(lang) for lang in langs]
         elif self.subtitles_setting == MATCHING or (
             self.subtitles_enough and self.subtitles_setting == NONE
         ):
             subtitles = [
-                {
-                    "languageName": self.lang_display_string(
-                        lang["languageCode"], lang["languageName"]
-                    ),
-                    "languageCode": lang["languageCode"],
-                }
+                self.get_subtitle_dict(lang)
                 for lang in langs
                 if lang["languageCode"] == current_lang
             ]
         elif self.subtitles_setting and self.subtitles_setting != NONE:
             if not self.subtitles_enough and self.topics:
                 subtitles = [
-                    {
-                        "languageName": self.lang_display_string(
-                            lang["languageCode"], lang["languageName"]
-                        ),
-                        "languageCode": lang["languageCode"],
-                    }
+                    self.get_subtitle_dict(lang)
                     for lang in langs
                     if lang["languageCode"] in self.subtitles_setting
                 ]
             else:
                 subtitles = [
-                    {
-                        "languageName": self.lang_display_string(
-                            lang["languageCode"], lang["languageName"]
-                        ),
-                        "languageCode": lang["languageCode"],
-                    }
+                    self.get_subtitle_dict(lang)
                     for lang in langs
                     if lang["languageCode"] in self.subtitles_setting
                     or lang["languageCode"] in self.source_language


### PR DESCRIPTION
This one combines the --language and --only-videos-in args. If no --language is specified, default language for zim is "eng". Only the --language argument prevails now and can take multiple values; that too in any format (conventions take place using a future version of zimwriterfs).

The following changes are introduced -
- support for --language with --playlists (Getting multiple language texts in playlist videos)
- support for automatic language selection for ZIM based on the --language value
- user can input language in any format to --language and/or --subtitle args. For languages with multiple versions, (say zh-cn, zh-tw, zh), if query is exact, exact code is put. If it's not exact, all versions are put into list. Eg - If query is zh, only zh is put in language list. If query is Chinese, all 3 are put in language list.
- support for native language names in the language filter and subtitle dropdowns