### PR TITLE
Use temporary directory by default for building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # dev
 
 - added ted2zim-multi for multi zim creation
-- added --build-dir option to specify custom build dir
-- use temporary directory as build directory by default
+- added --tmp-dir to specify the path folder where the temporary build directory will be created
 
 # 2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # dev
 
 - added ted2zim-multi for multi zim creation
+- added --build-dir option to specify custom build dir
+- use temporary directory as build directory by default
 
 # 2.0.2
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ You can create ZIMs for multiple topics (should be same as given [here](https://
         "name": "sample_name_{identity}",
         "description": "Sample description",
         "title": "Custom title",
-        "zim_file": "sample.zim",
+        "zim-file": "sample.zim",
         "tags": "tag",
-        "creator": "Yourself"
+        "creator": "Yourself",
+        "build-dir": "/custom_build_dir"
     }
 }
 ```

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -109,7 +109,7 @@ def main():
     )
 
     parser.add_argument(
-        "--build-dir", help="Custom build folder to build ZIM from",
+        "--tmp-dir", help="Path to create temp folder in. Used for building ZIM file. Receives all data (storage space)",
     )
 
     parser.add_argument(

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -109,6 +109,10 @@ def main():
     )
 
     parser.add_argument(
+        "--build-dir", help="Custom build folder to build ZIM from",
+    )
+
+    parser.add_argument(
         "--zim-file",
         help="ZIM file name (based on --name if not provided)",
         dest="fname",

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -109,7 +109,8 @@ def main():
     )
 
     parser.add_argument(
-        "--tmp-dir", help="Path to create temp folder in. Used for building ZIM file. Receives all data (storage space)",
+        "--tmp-dir",
+        help="Path to create temp folder in. Used for building ZIM file. Receives all data (storage space)",
     )
 
     parser.add_argument(

--- a/ted2zim/multi/entrypoint.py
+++ b/ted2zim/multi/entrypoint.py
@@ -9,28 +9,6 @@ from ..constants import NAME, SCRAPER, getLogger, setDebug
 from ..utils import has_argument
 
 
-def check_passed_args(args, extra_args, parser):
-    # prevent setting --title and --description
-    for arg in ("name", "title", "description", "zim-file"):
-        if args.indiv_zims and has_argument(arg, extra_args):
-            parser.error(
-                f"Can't use --{arg} in individual ZIMs mode. Use --{arg}-format to set format."
-            )
-
-    # name-format mandatory if indiv-zims and metadata file not specified
-    if not args.metadata_from:
-        if args.indiv_zims and not args.name_format:
-            parser.error("--name-format is mandatory in individual ZIMs mode")
-
-        if "{identity}" not in args.name_format:
-            parser.error("--name-format must have {identity} to ensure unique names")
-
-        if args.build_dir_format and "{identity}" not in args.build_dir_format:
-            parser.error(
-                "--build-dir-format must have {identity} to ensure unique names for custom build directories"
-            )
-
-
 def main():
     parser = argparse.ArgumentParser(
         prog=f"{NAME}-multi",
@@ -74,11 +52,6 @@ def main():
     )
 
     parser.add_argument(
-        "--build-dir-format",
-        help="Custom format for build directory names for individual ZIMs",
-    )
-
-    parser.add_argument(
         "--metadata-from",
         help="File path or URL to a JSON file holding custom metadata for individual playlists/topics. Format in README",
     )
@@ -96,7 +69,16 @@ def main():
 
     args, extra_args = parser.parse_known_args()
 
-    check_passed_args(args, extra_args, parser)
+    # prevent setting --title and --description
+    for arg in ("name", "title", "description", "zim-file"):
+        if args.indiv_zims and has_argument(arg, extra_args):
+            parser.error(
+                f"Can't use --{arg} in individual ZIMs mode. Use --{arg}-format to set format."
+            )
+
+    # name-format mandatory if indiv-zims
+    if args.indiv_zims and not args.name_format:
+        parser.error("--name-format is mandatory in individual ZIMs mode")
 
     setDebug(args.debug)
     logger = getLogger()

--- a/ted2zim/multi/entrypoint.py
+++ b/ted2zim/multi/entrypoint.py
@@ -59,6 +59,11 @@ def main():
     )
 
     parser.add_argument(
+        "--build-dir-format",
+        help="Custom format for build directory names for individual ZIMs",
+    )
+
+    parser.add_argument(
         "--metadata-from",
         help="File path or URL to a JSON file holding custom metadata for individual playlists/topics. Format in README",
     )
@@ -86,6 +91,18 @@ def main():
     # name-format mandatory if indiv-zims and metadata file not specified
     if args.indiv_zims and not args.name_format and not args.metadata_from:
         parser.error("--name-format is mandatory in individual ZIMs mode")
+
+    if "{identity}" not in args.name_format and not args.metadata_from:
+        parser.error("--name-format must have {identity} to ensure unique names")
+
+    if (
+        args.build_dir_format
+        and "{identity}" not in args.build_dir_format
+        and not args.metadata_from
+    ):
+        parser.error(
+            "--build-dir-format must have {identity} to ensure unique names for custom build directories"
+        )
 
     setDebug(args.debug)
     logger = getLogger()

--- a/ted2zim/multi/entrypoint.py
+++ b/ted2zim/multi/entrypoint.py
@@ -27,13 +27,6 @@ def main():
     )
 
     parser.add_argument(
-        "--output",
-        help="Output folder for ZIM file or build folder",
-        default="/output",
-        dest="output_dir",
-    )
-
-    parser.add_argument(
         "--indiv-zims",
         help="Make individual ZIMs for topics. Multiple ZIMs are always created for multiple playlists",
         action="store_true",

--- a/ted2zim/multi/scraper.py
+++ b/ted2zim/multi/scraper.py
@@ -235,7 +235,9 @@ class TedHandler(object):
 
         # ensure we supplied a name
         if not has_argument("name", args):
-            args += ["--name", self.compute_format(item, self.name_format)]
+            raise ValueError(
+                "Cannot supply a --name argument to ted2zim. Ensure you have a supplied either --name-format or have name in metadata JSON"
+            )
 
         # append regular ted2zim args
         args += self.extra_args

--- a/ted2zim/multi/scraper.py
+++ b/ted2zim/multi/scraper.py
@@ -7,6 +7,7 @@ import re
 import sys
 import json
 import pathlib
+import shutil
 import datetime
 import subprocess
 
@@ -201,21 +202,17 @@ class TedHandler(object):
     def run_indiv_zim_mode(self, item, mode):
         """ run ted2zim for an individual topic/playlist """
 
-        args = self.ted2zim_exe
+        args = self.ted2zim_exe + ["--output", str(self.output_dir)]
 
         if mode == "topic":
             args += [
                 "--topics",
                 item,
-                "--output",
-                str(self.output_dir.joinpath("topics", item.replace(" ", "_"))),
             ]
         elif mode == "playlist":
             args += [
                 "--playlist",
                 item,
-                "--output",
-                str(self.output_dir.joinpath("playlists", item)),
             ]
         else:
             raise ValueError(f"Unsupported mode {mode}")
@@ -229,6 +226,7 @@ class TedHandler(object):
             "description",
             "tags",
             "creator",
+            "build-dir",
         ):
             # use value from metadata JSON if present else from command-line
             value = metadata.get(
@@ -260,20 +258,16 @@ class TedHandler(object):
     def handle_single_zim(self, mode):
         """ redirect request to standard ted2zim """
 
-        args = self.ted2zim_exe
+        args = self.ted2zim_exe + ["--output", str(self.output_dir)]
         if mode == "topic":
             args += [
                 "--topics",
                 ",".join(self.topics),
-                "--output",
-                str(self.output_dir.joinpath("topics")),
             ]
         elif mode == "playlist":
             args += [
                 "--playlist",
                 self.playlists[0],
-                "--output",
-                str(self.output_dir.joinpath("playlists")),
             ]
         else:
             raise ValueError(f"Unsupported mode {mode}")

--- a/ted2zim/multi/scraper.py
+++ b/ted2zim/multi/scraper.py
@@ -7,7 +7,6 @@ import re
 import sys
 import json
 import pathlib
-import tempfile
 import datetime
 import subprocess
 
@@ -16,7 +15,7 @@ from zimscraperlib.logging import nicer_args_join
 from kiwixstorage import KiwixStorage
 
 from ..constants import NAME, getLogger
-from ..utils import download_link
+from ..utils import download_link, get_temp_fpath
 
 logger = getLogger()
 
@@ -74,43 +73,43 @@ class TedHandler(object):
         return records
 
     def download_playlists_list_from_cache(self, key, s3_storage):
-        fpath = pathlib.Path(tempfile.NamedTemporaryFile(delete=False).name)
-        if not s3_storage.has_object(key):
-            return False
-        try:
-            meta = s3_storage.get_object_stat(key).meta
-            if datetime.datetime.fromisoformat(
-                meta.get("retrieved_on")
-            ) > datetime.datetime.now() - datetime.timedelta(days=7):
-                s3_storage.download_file(key, fpath)
-            else:
-                logger.debug(
-                    "playlists_list.json in optimization cache is too old to be used"
-                )
+        with get_temp_fpath() as fpath:
+            if not s3_storage.has_object(key):
                 return False
-        except Exception as exc:
-            logger.error(f"{key} failed to download from cache: {exc}")
-            return False
-        logger.info(f"downloaded playlist list from cache at {key}")
-        with open(fpath, "r") as fp:
-            json_data = json.load(fp)
-        fpath.unlink()
-        return json_data
+            try:
+                meta = s3_storage.get_object_stat(key).meta
+                if datetime.datetime.fromisoformat(
+                    meta.get("retrieved_on")
+                ) > datetime.datetime.now() - datetime.timedelta(days=7):
+                    s3_storage.download_file(key, fpath)
+                else:
+                    logger.debug(
+                        "playlists_list.json in optimization cache is too old to be used"
+                    )
+                    return False
+            except Exception as exc:
+                logger.error(f"{key} failed to download from cache: {exc}")
+                return False
+            logger.info(f"downloaded playlist list from cache at {key}")
+            with open(fpath, "r") as fp:
+                json_data = json.load(fp)
+
+            return json_data
 
     def upload_playlists_list_to_cache(self, playlists_list, key, s3_storage):
-        fpath = pathlib.Path(tempfile.NamedTemporaryFile(delete=False).name)
-        with open(fpath, "w") as fp:
-            json.dump(playlists_list, fp)
-        try:
-            s3_storage.upload_file(
-                fpath, key, meta={"retrieved_on": datetime.datetime.now().isoformat()},
-            )
-        except Exception as exc:
-            logger.error(f"{key} failed to upload to cache: {exc}")
-        else:
-            logger.info(f"successfully uploaded playlist list to cache at {key}")
-        finally:
-            fpath.unlink()
+        with get_temp_fpath() as fpath:
+            with open(fpath, "w") as fp:
+                json.dump(playlists_list, fp)
+            try:
+                s3_storage.upload_file(
+                    fpath,
+                    key,
+                    meta={"retrieved_on": datetime.datetime.now().isoformat()},
+                )
+            except Exception as exc:
+                logger.error(f"{key} failed to upload to cache: {exc}")
+            else:
+                logger.info(f"successfully uploaded playlist list to cache at {key}")
 
     def get_list_of_all(self, mode):
         """ returns a list of topics or playlists"""
@@ -138,8 +137,8 @@ class TedHandler(object):
             ):
                 logger.error("S3 credential check failed. Continuing without S3")
                 return self.download_playlists_list_from_site(topics_list)
+
             key = "playlists_list.json"
-            self.output_dir.mkdir(parents=True, exist_ok=True)
             playlists_list = self.download_playlists_list_from_cache(key, s3_storage)
             if not playlists_list:
                 logger.debug("Attempting to retrieve playlists list from TED")

--- a/ted2zim/multi/scraper.py
+++ b/ted2zim/multi/scraper.py
@@ -16,7 +16,7 @@ from zimscraperlib.logging import nicer_args_join
 from kiwixstorage import KiwixStorage
 
 from ..constants import NAME, getLogger
-from ..utils import has_argument, download_link
+from ..utils import download_link
 
 logger = getLogger()
 
@@ -223,7 +223,6 @@ class TedHandler(object):
             "description",
             "tags",
             "creator",
-            "build-dir",
         ):
             # use value from metadata JSON if present else from command-line
             value = metadata.get(
@@ -232,12 +231,6 @@ class TedHandler(object):
 
             if value:  # only set arg if we have a value so it can be defaulted
                 args += [f"--{key}", self.compute_format(item, str(value))]
-
-        # ensure we supplied a name
-        if not has_argument("name", args):
-            raise ValueError(
-                "Cannot supply a --name argument to ted2zim. Ensure you have a supplied either --name-format or have name in metadata JSON"
-            )
 
         # append regular ted2zim args
         args += self.extra_args

--- a/ted2zim/multi/scraper.py
+++ b/ted2zim/multi/scraper.py
@@ -7,7 +7,7 @@ import re
 import sys
 import json
 import pathlib
-import shutil
+import tempfile
 import datetime
 import subprocess
 
@@ -36,9 +36,6 @@ class TedHandler(object):
                 setattr(self, key, value_list)
 
         self.extra_args = extra_args
-
-        self.output_dir = pathlib.Path(self.output_dir).expanduser().resolve()
-        self.build_dir = self.output_dir.joinpath("build")
 
         # metadata_from JSON file
         self.metadata_from = (
@@ -77,7 +74,7 @@ class TedHandler(object):
         return records
 
     def download_playlists_list_from_cache(self, key, s3_storage):
-        fpath = self.output_dir.joinpath("playlists_list.json")
+        fpath = pathlib.Path(tempfile.NamedTemporaryFile(delete=False).name)
         if not s3_storage.has_object(key):
             return False
         try:
@@ -101,7 +98,7 @@ class TedHandler(object):
         return json_data
 
     def upload_playlists_list_to_cache(self, playlists_list, key, s3_storage):
-        fpath = self.output_dir.joinpath("playlists_list.json")
+        fpath = pathlib.Path(tempfile.NamedTemporaryFile(delete=False).name)
         with open(fpath, "w") as fp:
             json.dump(playlists_list, fp)
         try:
@@ -202,7 +199,7 @@ class TedHandler(object):
     def run_indiv_zim_mode(self, item, mode):
         """ run ted2zim for an individual topic/playlist """
 
-        args = self.ted2zim_exe + ["--output", str(self.output_dir)]
+        args = self.ted2zim_exe
 
         if mode == "topic":
             args += [
@@ -258,7 +255,7 @@ class TedHandler(object):
     def handle_single_zim(self, mode):
         """ redirect request to standard ted2zim """
 
-        args = self.ted2zim_exe + ["--output", str(self.output_dir)]
+        args = self.ted2zim_exe
         if mode == "topic":
             args += [
                 "--topics",

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -84,7 +84,7 @@ class Ted2Zim:
         self.output_dir = pathlib.Path(output_dir).expanduser().resolve()
         self.temp_dir = tempfile.TemporaryDirectory() if not build_dir else None
         self.custom_build_dir = (
-            pathlib.Path(build_dir).expanduser().resolve if build_dir else None
+            pathlib.Path(build_dir).expanduser().resolve() if build_dir else None
         )
 
         # scraper options

--- a/ted2zim/utils.py
+++ b/ted2zim/utils.py
@@ -8,6 +8,11 @@ import json
 import requests
 
 
+def has_argument(arg_name, all_args):
+    """ whether --arg_name is specified in all_args """
+    return list(filter(lambda x: x.startswith(f"--{arg_name}"), all_args))
+
+
 def update_subtitles_list(video_id, language_list):
     """ adds `link` to each language dict containing the subtitle url """
 

--- a/ted2zim/utils.py
+++ b/ted2zim/utils.py
@@ -4,6 +4,9 @@
 
 import time
 import json
+import pathlib
+import tempfile
+import contextlib
 
 import requests
 
@@ -94,3 +97,14 @@ class WebVTT:
                 )
                 document += content + "\n\n"
         return document
+
+
+@contextlib.contextmanager
+def get_temp_fpath(**kwargs):
+    try:
+        fh = tempfile.NamedTemporaryFile(delete=False, **kwargs)
+        fpath = pathlib.Path(fh.name)
+        fh.close()
+        yield fpath
+    finally:
+        fpath.unlink()


### PR DESCRIPTION
This adds ability to use temporary directory as build dir by default. Also adds --build-dir option to set a custom build dir. ted2zim-multi passes --output directly.