### PR TITLE
Changed identity to use dash instead of underscrores for spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - added ted2zim-multi for multi zim creation
 - added --tmp-dir to specify the path folder where the temporary build directory will be created
+- `{period}` can be passed in `--zim-file` and be replaced with date as YYYY-MM
 
 # 2.0.2
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,13 @@ You can create ZIMs for multiple topics (should be same as given [here](https://
 
 #### Want more flexibility? There's a multitool
 `ted2zim-multi` is an extra command available that allows you to do much more with the scraper. It falls back to `ted2zim` if normal commands are passed. It supports creation of multiple ZIMs with single command for both playlists and topics and even getting metadata from a specified JSON file. It supports the following extra arguments -
-- --indiv-zims - Allows you to create one zim/topic or one zim/playlist
-- --{name|description|zim-file|title}-format - Allows you to add custom format for the equivalent `ted2zim` arguments. You can add {identity} as a placeholder in these values to get the playlist ID / topic name in it's place
-- --metadata-from - Path to a JSON file containing the metadata. Should be of the following format -
+
+- `--indiv-zims` - Allows you to create one zim/topic or one zim/playlist
+- `--{name|description|zim-file|title}-format` - Allows you to add custom format for the equivalent `ted2zim` arguments. You can add `{identity}` as a placeholder in these values to get the playlist ID / topic name in it's place (spaces replaced by `-`).
+- `--metadata-from` - Path to a JSON file containing the metadata.
+
+Should be of the following format:
+
 ```bash
 {
     "<playlist-id/topic-name-with-underscores>": {
@@ -90,7 +94,8 @@ You can create ZIMs for multiple topics (should be same as given [here](https://
     }
 }
 ```
-See ted2zim-multi --help for details.
+
+See `ted2zim-multi --help` for details.
 
 ## License :book:
 

--- a/ted2zim/multi/scraper.py
+++ b/ted2zim/multi/scraper.py
@@ -55,7 +55,7 @@ class TedHandler(object):
 
     @staticmethod
     def compute_format(item, fmt):
-        return fmt.format(identity=item.replace(" ", "_"))
+        return fmt.format(identity=item.replace(" ", "-"), period="{}")
 
     @staticmethod
     def download_playlists_list_from_site(topics_list):

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -919,12 +919,9 @@ class Ted2Zim:
 
         # zim creation and cleanup
         if not self.no_zim:
-            period = datetime.datetime.now().strftime("%Y-%m")
             self.fname = (
-                self.fname
-                if self.fname
-                else f"{self.name.replace(' ', '_')}_{period}.zim"
-            )
+                self.fname or f"{self.name.replace(' ', '-')}_{{period}}.zim"
+            ).format(period=datetime.datetime.now().strftime("%Y-%m"))
             logger.info("building ZIM file")
             self.zim_info.update(
                 title=self.title, description=self.description, language=self.zim_lang


### PR DESCRIPTION
The Kiwix/OpenZIM toolchain requires a specific naming in ZIM files and that prevents
the use of underscores in some parts of the filename.
Because we now generate ZIM files dynamically from the request (multi mode), we need
to make sure those can be custom, using `{identity}` yet still valid on our server.
`{identity}` now replaces spaces with `-` instead of `_`.

Additionnaly, `--zim-file` now accepts `{period}` in the same custom/practical spirit.

README was also edited to be readable even outside github