### PR TITLE
Do not allow abbreviations and crash on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.0.4.dev0
 
-- n/a
+- ted2zim-multi now returns correct return codes
+- argument abbreviations not allowed in ted2zim-multi to prevent --name being read as --name-format
 
 # 2.0.3
 

--- a/ted2zim/multi/entrypoint.py
+++ b/ted2zim/multi/entrypoint.py
@@ -70,6 +70,14 @@ def main():
 
     args, extra_args = parser.parse_known_args()
 
+    # prevent launching without any topic(s)/playlist(s)
+    if (
+        not args.playlists
+        and not args.topics
+        and not has_argument("playlist", extra_args)
+    ):
+        parser.error("Please provide topic(s) and/or playlist(s) to scrape")
+
     # prevent setting --title and --description
     for arg in ("name", "title", "description", "zim-file"):
         if args.indiv_zims and has_argument(arg, extra_args):

--- a/ted2zim/multi/entrypoint.py
+++ b/ted2zim/multi/entrypoint.py
@@ -89,7 +89,7 @@ def main():
 
     try:
         handler = TedHandler(dict(args._get_kwargs()), extra_args=extra_args)
-        handler.run()
+        raise SystemExit(handler.run())
     except Exception as exc:
         logger.error(f"FAILED. An error occurred: {exc}")
         if args.debug:

--- a/ted2zim/multi/entrypoint.py
+++ b/ted2zim/multi/entrypoint.py
@@ -14,6 +14,7 @@ def main():
         prog=f"{NAME}-multi",
         description="Scraper to create ZIM file(s) from TED topic(s) or playlist(s)",
         epilog="All titles, descriptions and names can use the {identity} to get playlist ID or topic name (with underscores) in each case",
+        allow_abbrev=False,
     )
 
     parser.add_argument(

--- a/ted2zim/multi/scraper.py
+++ b/ted2zim/multi/scraper.py
@@ -212,8 +212,7 @@ class TedHandler(object):
             if self.indiv_zims:
                 logger.info(f"Starting {NAME}-multi scraper for playlists")
                 return self.handle_indiv_playlists()
-            else:
-                return self.handle_single_zim(mode="playlist")
+            return self.handle_single_zim(mode="playlist")
 
     def run_indiv_zim_mode(self, item, mode):
         """ run ted2zim for an individual topic/playlist """

--- a/ted2zim/multi/scraper.py
+++ b/ted2zim/multi/scraper.py
@@ -171,10 +171,13 @@ class TedHandler(object):
                     success, process = self.run_indiv_zim_mode(topic, mode="topic")
                     self.log_run_result(success, process)
                     if not success:
-                        raise Exception(f"ted2zim Failed with: {process.returncode}")
+                        return process.returncode
 
             else:
-                self.handle_single_zim(mode="topic")
+                success, process = self.handle_single_zim(mode="topic")
+                self.log_run_result(success, process)
+                if not success:
+                    return process.returncode
 
         if self.playlists:
             if self.playlists == ["all"]:
@@ -193,9 +196,12 @@ class TedHandler(object):
                     )
                     self.log_run_result(success, process)
                     if not success:
-                        raise Exception(f"ted2zim Failed with: {process.returncode}")
+                        return process.returncode
             else:
                 self.handle_single_zim(mode="playlist")
+                self.log_run_result(success, process)
+                if not success:
+                    return process.returncode
 
     def run_indiv_zim_mode(self, item, mode):
         """ run ted2zim for an individual topic/playlist """
@@ -267,7 +273,13 @@ class TedHandler(object):
         args += self.extra_args
         if self.debug:
             args += ["--debug"]
-        subprocess.run(args, check=True)
+        process = subprocess.run(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+        return process.returncode == 0, process
 
     def fetch_metadata(self):
         """ retrieves and loads metadata from --metadata-from """

--- a/ted2zim/multi/scraper.py
+++ b/ted2zim/multi/scraper.py
@@ -154,7 +154,6 @@ class TedHandler(object):
         else:
             logger.error(".. ERROR. Printing scraper output and exiting.")
             logger.error(process.stdout)
-            return process.returncode
 
     def run(self):
         logger.info(f"starting {NAME}-multi scraper")
@@ -171,10 +170,11 @@ class TedHandler(object):
                     logger.info(f"Executing ted2zim for topic {topic}")
                     success, process = self.run_indiv_zim_mode(topic, mode="topic")
                     self.log_run_result(success, process)
+                    if not success:
+                        raise Exception(f"ted2zim Failed with: {process.returncode}")
 
             else:
-                if not self.handle_single_zim(mode="topic"):
-                    logger.error("ted2zim Failed")
+                self.handle_single_zim(mode="topic")
 
         if self.playlists:
             if self.playlists == ["all"]:
@@ -192,9 +192,10 @@ class TedHandler(object):
                         playlist, mode="playlist"
                     )
                     self.log_run_result(success, process)
+                    if not success:
+                        raise Exception(f"ted2zim Failed with: {process.returncode}")
             else:
-                if not self.handle_single_zim(mode="playlist"):
-                    logger.error("ted2zim Failed")
+                self.handle_single_zim(mode="playlist")
 
     def run_indiv_zim_mode(self, item, mode):
         """ run ted2zim for an individual topic/playlist """
@@ -266,7 +267,7 @@ class TedHandler(object):
         args += self.extra_args
         if self.debug:
             args += ["--debug"]
-        return subprocess.run(args).returncode == 0
+        subprocess.run(args, check=True)
 
     def fetch_metadata(self):
         """ retrieves and loads metadata from --metadata-from """


### PR DESCRIPTION
Fixes #89 and #90 by doing the following -
-Not allowing abbreviations in argument parser (--name was filling --name-format)
- Raise exception and crash on error with any run