### PR TITLE
Add {slug} placeholder to be replaced by topic/playlist slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.0.5.dev0
 
 - use pylibzim to create zim
+- add variable "{slug}" in ted2zim-multi which will be replaced by the playlist/topic slug (with dashes) automatically
 
 # 2.0.4
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can create ZIMs for multiple topics (should be same as given [here](https://
 `ted2zim-multi` is an extra command available that allows you to do much more with the scraper. It falls back to `ted2zim` if normal commands are passed. It supports creation of multiple ZIMs with single command for both playlists and topics and even getting metadata from a specified JSON file. It supports the following extra arguments -
 
 - `--indiv-zims` - Allows you to create one zim/topic or one zim/playlist
-- `--{name|description|zim-file|title}-format` - Allows you to add custom format for the equivalent `ted2zim` arguments. You can add `{identity}` as a placeholder in these values to get the playlist ID / topic name in it's place (spaces replaced by `-`).
+- `--{name|description|zim-file|title}-format` - Allows you to add custom format for the equivalent `ted2zim` arguments. You can add `{identity}` as a placeholder in these values to get the playlist ID / topic name in it's place (spaces replaced by `-`). You can now also add `{slug}` to get the topic/playlist slug.
 - `--metadata-from` - Path to a JSON file containing the metadata.
 
 Should be of the following format:

--- a/ted2zim/multi/entrypoint.py
+++ b/ted2zim/multi/entrypoint.py
@@ -13,7 +13,7 @@ def main():
     parser = argparse.ArgumentParser(
         prog=f"{NAME}-multi",
         description="Scraper to create ZIM file(s) from TED topic(s) or playlist(s)",
-        epilog="All titles, descriptions and names can use the {identity} to get playlist ID or topic name (with underscores) in each case",
+        epilog="All titles, descriptions and names can use the variables {identity} to get playlist ID or topic name (with dashes) in each case, or {slug} to get the slug (with dashes)",
         allow_abbrev=False,
     )
 

--- a/ted2zim/multi/scraper.py
+++ b/ted2zim/multi/scraper.py
@@ -53,8 +53,10 @@ class TedHandler(object):
         return [sys.argv[0].replace(f"{cmd}-multi", cmd)]
 
     @staticmethod
-    def compute_format(item, fmt):
-        return fmt.format(identity=item.replace(" ", "-"), period="{}")
+    def compute_format(item, slug, fmt):
+        return fmt.format(
+            identity=item.replace(" ", "-"), period="{}", slug=slug.replace("_", "-")
+        )
 
     @staticmethod
     def download_playlists_list_from_site(topics_list):
@@ -224,11 +226,15 @@ class TedHandler(object):
                 "--topics",
                 item,
             ]
+            slug = item.replace(" ", "-")
         elif mode == "playlist":
             args += [
                 "--playlist",
                 item,
             ]
+            slug = requests.get(f"https://www.ted.com/playlists/{item}").url.replace(
+                f"https://www.ted.com/playlists/{item}/", ""
+            )
         else:
             raise ValueError(f"Unsupported mode {mode}")
 
@@ -248,7 +254,7 @@ class TedHandler(object):
             )
 
             if value:  # only set arg if we have a value so it can be defaulted
-                args += [f"--{key}", self.compute_format(item, str(value))]
+                args += [f"--{key}", self.compute_format(item, slug, str(value))]
 
         # append regular ted2zim args
         args += self.extra_args

--- a/ted2zim/multi/scraper.py
+++ b/ted2zim/multi/scraper.py
@@ -53,9 +53,15 @@ class TedHandler(object):
         return [sys.argv[0].replace(f"{cmd}-multi", cmd)]
 
     @staticmethod
-    def compute_format(item, slug, fmt):
-        return fmt.format(
-            identity=item.replace(" ", "-"), period="{}", slug=slug.replace("_", "-")
+    def compute_format(item, fmt, mode):
+        identity = item.replace(" ", "-")
+        slug = TedHandler.get_playlist_slug(item) if mode == "playlist" else identity
+        return fmt.format(identity=identity, period="{}", slug=slug.replace("_", "-"))
+
+    @staticmethod
+    def get_playlist_slug(item):
+        return requests.get(f"https://www.ted.com/playlists/{item}").url.replace(
+            f"https://www.ted.com/playlists/{item}/", ""
         )
 
     @staticmethod
@@ -226,15 +232,11 @@ class TedHandler(object):
                 "--topics",
                 item,
             ]
-            slug = item.replace(" ", "-")
         elif mode == "playlist":
             args += [
                 "--playlist",
                 item,
             ]
-            slug = requests.get(f"https://www.ted.com/playlists/{item}").url.replace(
-                f"https://www.ted.com/playlists/{item}/", ""
-            )
         else:
             raise ValueError(f"Unsupported mode {mode}")
 
@@ -254,7 +256,7 @@ class TedHandler(object):
             )
 
             if value:  # only set arg if we have a value so it can be defaulted
-                args += [f"--{key}", self.compute_format(item, slug, str(value))]
+                args += [f"--{key}", self.compute_format(item, str(value), mode)]
 
         # append regular ted2zim args
         args += self.extra_args


### PR DESCRIPTION
This fixes #94 by adding a placeholder called {slug} that is replaced by the topic/playlist slug replaced by dashes. For topics, {slug} and {identity} yield the same result.