### PR TITLE
Use slugify on unquoted string

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ beautifulsoup4==4.9.1
 Jinja2==2.10.1
 kiwixstorage>=0.2,<1.0
 pif==0.8.2
+python-slugify>=4.0.1,<4.1

--- a/ted2zim/multi/scraper.py
+++ b/ted2zim/multi/scraper.py
@@ -7,10 +7,12 @@ import sys
 import time
 import json
 import pathlib
+import urllib
 import datetime
 import subprocess
 
 import requests
+from slugify import slugify
 from zimscraperlib.logging import nicer_args_join
 from kiwixstorage import KiwixStorage
 
@@ -68,7 +70,10 @@ class TedHandler(object):
             resp = requests.get(partial_url, allow_redirects=True)
             if resp.status_code == 200:
                 # we get the slug from the final url after the partial url gets redirected
-                return resp.url.replace(partial_url, "")
+                return slugify(
+                    urllib.parse.unquote(resp.url.replace(partial_url, "")),
+                    separator="-",
+                )
             time.sleep(30 * attempt)
         raise Exception(f"Could not get slug for playlist {item}")
 


### PR DESCRIPTION
This fixes #102 by using urllib.parse.unquote to unquote the slug received from the URL and then slugifying it using python-slugify to prevent throwing up errors due to invalid names.

The changes are only in the following lines -
requirements.txt - line 8
ted2zim/multi/scraper.py - lines 10, 15, 73, 74, 75, 76

All other changes are due to the new black formatter