### PR TITLE
WebP support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.0.6.dev0
 
 - [multi] added retry over failure to get playlist slug
+- use WebP images instead of JPEG for thumbnails and speaker images
 
 # 2.0.5
 

--- a/get_js_deps.sh
+++ b/get_js_deps.sh
@@ -55,6 +55,14 @@ mv videojs-ogvjs-1.3.1/dist/videojs-ogvjs.js $ASSETS_PATH/videojs-ogvjs.js
 rm -rf videojs-ogvjs-1.3.1
 rm -f v1.3.1.zip
 
+echo "getting webp-hero"
+curl -L -O https://unpkg.com/webp-hero@0.0.0-dev.26/dist-cjs/polyfills.js
+rm -f $ASSETS_PATH/polyfills.js
+mv polyfills.js $ASSETS_PATH/polyfills.js
+curl -L -O https://unpkg.com/webp-hero@0.0.0-dev.26/dist-cjs/webp-hero.bundle.js
+rm -f $ASSETS_PATH/webp-hero.bundle.js
+mv webp-hero.bundle.js $ASSETS_PATH/webp-hero.bundle.js
+
 if command -v fix_ogvjs_dist > /dev/null; then
     echo "fixing JS files"
     fix_ogvjs_dist $ASSETS_PATH "assets"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil==2.8.1
-zimscraperlib>=1.2.0,<1.3
+zimscraperlib>=1.3.2,<1.4
 requests>=2.23,<3.0
 beautifulsoup4==4.9.1
 Jinja2==2.10.1

--- a/ted2zim/processing.py
+++ b/ted2zim/processing.py
@@ -3,7 +3,6 @@
 # vim: ai ts=4 sts=4 et sw=4 nu
 
 from zimscraperlib.video.encoding import reencode
-from zimscraperlib.imaging import resize_image
 
 from .constants import getLogger
 
@@ -31,14 +30,6 @@ def post_process_video(
             f"Multiple video file candidates for {video_id} in {video_dir}. Picking {files[0]} out of {files}"
         )
     src_path = files[0]
-
-    # resize thumbnail. we use max width:248x187px in listing
-    resize_image(
-        src_path.parent.joinpath("thumbnail.jpg"),
-        width=248,
-        height=187,
-        method="cover",
-    )
 
     # don't reencode if not requesting low-quality and received wanted format
     if skip_recompress or (not low_quality and src_path.suffix[1:] == video_format):

--- a/ted2zim/templates/article.html
+++ b/ted2zim/templates/article.html
@@ -27,7 +27,7 @@
             <div id="video-wrapper">
                 <video class="video-js vjs-default-skin vjs-fill"
                     controls preload="auto"
-                    poster="videos/{{ video_id }}/thumbnail.jpg"
+                    poster="videos/{{ video_id }}/thumbnail.webp"
                     data-setup='{"techOrder": ["html5", "ogvjs"], "ogvjs": {"base": "assets/ogvjs"}, "autoplay": {% if autoplay %}true{% else %}false{% endif %}, "preload": true, "controls": true, "controlBar": {"pictureInPictureToggle":false}}'>
                     <source src="videos/{{ video_id }}/video.{{ video_format }}" type="video/{{ video_format }}" />
                         {% for language in languages %}
@@ -45,7 +45,7 @@
                 <div id="speaker_box_img">
                     <div>
                         {% if speaker_img %}
-                          <img id="speaker_img" src="videos/{{ video_id }}/speaker.jpg">
+                          <img id="speaker_img" src="videos/{{ video_id }}/speaker.webp">
                         {% endif %}
                         <div id="speaker_info">
                             <div id="speaker_info_box">{{ speaker }}</div>

--- a/ted2zim/templates/article.html
+++ b/ted2zim/templates/article.html
@@ -59,8 +59,18 @@
             </div>
             <script>
                 $(document).ready(function() {
-                  let webpMachine = new webpHero.WebpMachine();
-                  webpMachine.polyfillDocument();
+                    webpHero.detectWebpSupport().then(function (support_webp){
+                        if (!support_webp) {
+                            console.log("no WebP support, polyfilling.");
+                            // un-hide ogvjs-poster so the polyfill can transform it
+                            $(".ogvjs-poster").css("visibility", "");
+                            // hide video-js poster (which uses background-image)
+                            $(".vjs-poster").css("display", "none");
+
+                            let webpMachine = new webpHero.WebpMachine();
+                            webpMachine.polyfillDocument();
+                        }
+                    });
                 });
             </script>
         </body>

--- a/ted2zim/templates/article.html
+++ b/ted2zim/templates/article.html
@@ -58,8 +58,10 @@
                 </div>
             </div>
             <script>
-                var webpMachine = new webpHero.WebpMachine()
-                webpMachine.polyfillDocument()
+                $(document).ready(function() {
+                  let webpMachine = new webpHero.WebpMachine();
+                  webpMachine.polyfillDocument();
+                });
             </script>
         </body>
     </html>

--- a/ted2zim/templates/article.html
+++ b/ted2zim/templates/article.html
@@ -15,7 +15,9 @@
         <script src="assets/ogvjs/ogv.js"></script>
         <script src="assets/videojs-ogvjs.js"></script>
         <script src="assets/jquery.min.js"></script>
-        <script src="assets/article.js"></script>        
+        <script src="assets/article.js"></script>
+        <script src="assets/polyfills.js"></script>
+        <script src="assets/webp-hero.bundle.js"></script>        
     </head>
     <body>
         <div id="content">
@@ -55,5 +57,9 @@
                     </div>
                 </div>
             </div>
+            <script>
+                var webpMachine = new webpHero.WebpMachine()
+                webpMachine.polyfillDocument()
+            </script>
         </body>
     </html>

--- a/ted2zim/templates/assets/app.js
+++ b/ted2zim/templates/assets/app.js
@@ -130,7 +130,7 @@ function refreshVideos(language, pageData) {
       a.className = 'nostyle'
 
       var img = document.createElement('img');
-      img.src = ZIM_IMG_NS+'videos/'+video['id']+'/thumbnail.jpg';
+      img.src = ZIM_IMG_NS+'videos/'+video['id']+'/thumbnail.webp';
 
       var author = document.createElement('p');
       author.id = 'author';

--- a/ted2zim/templates/home.html
+++ b/ted2zim/templates/home.html
@@ -43,8 +43,10 @@
   <script src="assets/db.js"></script>
   <script src="assets/app.js"></script>
   <script>
-    var webpMachine = new webpHero.WebpMachine()
-    webpMachine.polyfillDocument()
+    $(document).ready(function() {
+      let webpMachine = new webpHero.WebpMachine();
+      webpMachine.polyfillDocument();
+    });
   </script>
 </body>
 </html>

--- a/ted2zim/templates/home.html
+++ b/ted2zim/templates/home.html
@@ -44,9 +44,14 @@
   <script src="assets/app.js"></script>
   <script>
     $(document).ready(function() {
-      let webpMachine = new webpHero.WebpMachine();
-      webpMachine.polyfillDocument();
-    });
+      webpHero.detectWebpSupport().then(function (support_webp){
+          if (!support_webp) {
+              console.log("no WebP support, polyfilling.");
+              let webpMachine = new webpHero.WebpMachine();
+              webpMachine.polyfillDocument();
+          }
+      });
+  });
   </script>
 </body>
 </html>

--- a/ted2zim/templates/home.html
+++ b/ted2zim/templates/home.html
@@ -10,6 +10,8 @@
     <script src="assets/zim_prefix.js"></script>
     <link href="assets/home.css" rel="stylesheet" type="text/css">
     <link href="assets/chosen/chosen.min.css" rel="stylesheet" type="text/css">
+    <script src="assets/polyfills.js"></script>
+    <script src="assets/webp-hero.bundle.js"></script>
   </head>
   <body>
     <div class="container">
@@ -40,5 +42,9 @@
   <script src="assets/data.js"></script>
   <script src="assets/db.js"></script>
   <script src="assets/app.js"></script>
+  <script>
+    var webpMachine = new webpHero.WebpMachine()
+    webpMachine.polyfillDocument()
+  </script>
 </body>
 </html>


### PR DESCRIPTION
This enables the use of WebP instead of JPEG for thumbnails and speaker images.
The S3 cache is also extended to have support for WebP images

The following new methods are added -
- `download_jpeg_image_and_convert()` - Downloads a JPEG image and converts, resizes and optimizes them
- `download_speaker_image()` - Downloads the speaker image from cache or URL
- `download_thumbnail()` - Downloads the thumbnail from cache or URL

The `download_video_files()` method is modified to use the aforementioned new methods and `video_path` is renamed to `object_path` in the S3 methods. The templates are also modified to use new WebP images

Note  - This depends on `zimscraperlib` 1.3.2 (which is yet to be released) or newer