### PR TITLE
Use slug for URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - add multithreading support and ability to download videos hosted on youtube
 - fixed usage on older browsers (without ES6 support)
 - limited YoutubeDownloader threads to 1
+- use slug instead of video ID to make urls meaningful
 
 # 2.0.5
 

--- a/ted2zim/templates/assets/app.js
+++ b/ted2zim/templates/assets/app.js
@@ -126,7 +126,7 @@ function refreshVideos(language, pageData) {
       var li = document.createElement('li');
       
       var a = document.createElement('a')
-      a.href =  video['id']+'.html?lang=' + lang;
+      a.href =  video['slug']+'?lang=' + lang;
       a.className = 'nostyle'
 
       var img = document.createElement('img');


### PR DESCRIPTION
This fixes #83 by using slug for URLs instead of video IDs. Also removes the `.html` extension from pages.