### PR TITLE
Fix crash on no locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.0.7.dev0
 
-- n/a
+- use `eng` as default locale
 
 # 2.0.6
 

--- a/ted2zim/entrypoint.py
+++ b/ted2zim/entrypoint.py
@@ -31,6 +31,7 @@ def main():
         "--locale",
         help="The locale to use in the UI (can be iso language code / locale)",
         dest="locale_name",
+        default="eng",
     )
 
     parser.add_argument(


### PR DESCRIPTION
This fixes crash on no locale being supplied by using `en` as the default