### PR TITLE
Updated for new playlists DOM

### DIFF
--- a/get_js_deps.sh
+++ b/get_js_deps.sh
@@ -46,6 +46,7 @@ rm -rf $ASSETS_PATH/ogvjs
 unzip -o ogvjs-1.6.1.zip
 mv ogvjs-1.6.1 $ASSETS_PATH/ogvjs
 rm -f ogvjs-1.6.1.zip
+rm -f $ASSETS_PATH/ogvjs/COPYING $ASSETS_PATH/ogvjs/*.txt $ASSETS_PATH/ogvjs/README.md
 
 echo "getting videojs-ogvjs.js"
 curl -L -O https://github.com/hartman/videojs-ogvjs/archive/v1.3.1.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ python-dateutil==2.8.1
 zimscraperlib>=1.3.6,<1.4
 requests>=2.23,<3.0
 beautifulsoup4==4.9.1
-Jinja2==2.10.1
+Jinja2==2.11.3
 kiwixstorage>=0.2,<1.0
 pif==0.8.2
 python-slugify>=4.0.1,<4.1

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -226,10 +226,11 @@ class Ted2Zim:
         """
 
         playlist_url = f"{self.playlists_base_url}/{playlist}"
+        logger.debug(f"extract_videos_from_playlist: {playlist_url}")
         soup = BeautifulSoup(download_link(playlist_url).text, features="html.parser")
-        video_elements = soup.find_all("a", attrs={"class": "hover/appear"})
-        self.playlist_title = soup.find("h1", attrs={"class": "f:4"}).string
-        self.playlist_description = soup.find("p", attrs={"class": "m-b:2"}).string
+        video_elements = soup.find_all("a", attrs={"class": "group"})
+        self.playlist_title = soup.find("h1").string
+        self.playlist_description = soup.find("p", attrs={"class": "text-base"}).string
 
         for element in video_elements:
             relative_path = element.get("href")
@@ -253,6 +254,7 @@ class Ted2Zim:
 
         page = 1
         while True:
+            logger.debug(f"generate_search_result_and_scrape: {topic_url}&page={page}")
             html = download_link(f"{topic_url}&page={page}").text
             nb_videos_extracted, nb_videos_on_page = self.extract_videos_on_topic_page(
                 html
@@ -619,6 +621,7 @@ class Ted2Zim:
             logger.error("Max retries exceeded. Skipping video")
             return False
 
+        logger.debug(f"extract_info_from_video_page: {url}")
         soup = BeautifulSoup(download_link(url).text, features="html.parser")
         div = soup.find("div", attrs={"class": "talks-main"})
 


### PR DESCRIPTION
Playlists page DOM has changed. This fixes retrieving title/desc and video page urls.

We'll probably have similar issues in the two other places which rely on DOM parsing. Added urls to debug logs so we can fix those easily.