### PR TITLE
Adding title to ZIM entries

### DIFF
--- a/ted2zim/constants.py
+++ b/ted2zim/constants.py
@@ -32,10 +32,10 @@ class Global:
 
 
 def setDebug(debug):
-    """ toggle constants global DEBUG flag (used by getLogger) """
+    """toggle constants global DEBUG flag (used by getLogger)"""
     Global.debug = bool(debug)
 
 
 def getLogger():
-    """ configured logger respecting DEBUG flag """
+    """configured logger respecting DEBUG flag"""
     return lib_getLogger(NAME, level=logging.DEBUG if Global.debug else logging.INFO)

--- a/ted2zim/multi/scraper.py
+++ b/ted2zim/multi/scraper.py
@@ -48,7 +48,7 @@ class TedHandler(object):
 
     @property
     def ted2zim_exe(self):
-        """ ted2zim executable """
+        """ted2zim executable"""
 
         # handle either `python ted2zim` or `ted2zim`
         cmd = "ted2zim"
@@ -133,7 +133,7 @@ class TedHandler(object):
                 logger.info(f"successfully uploaded playlist list to cache at {key}")
 
     def get_list_of_all(self, mode):
-        """ returns a list of topics or playlists"""
+        """returns a list of topics or playlists"""
         # get all topics
         topics_list = json.loads(
             download_link("https://www.ted.com/topics/combo?models=Talks").text
@@ -236,7 +236,7 @@ class TedHandler(object):
             return self.handle_single_zim(mode="playlist")
 
     def run_indiv_zim_mode(self, item, mode):
-        """ run ted2zim for an individual topic/playlist """
+        """run ted2zim for an individual topic/playlist"""
 
         args = self.ted2zim_exe
 
@@ -287,7 +287,7 @@ class TedHandler(object):
         return process.returncode == 0, process
 
     def handle_single_zim(self, mode):
-        """ redirect request to standard ted2zim """
+        """redirect request to standard ted2zim"""
 
         args = self.ted2zim_exe
         if mode == "topic":
@@ -308,7 +308,7 @@ class TedHandler(object):
         return subprocess.run(args).returncode
 
     def fetch_metadata(self):
-        """ retrieves and loads metadata from --metadata-from """
+        """retrieves and loads metadata from --metadata-from"""
 
         if not self.metadata_from:
             return

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -250,7 +250,7 @@ class Ted2Zim:
             raise ValueError("Wrong playlist ID supplied. No videos found")
 
     def generate_search_result_and_scrape(self, topic_url, total_videos_scraped):
-        """ generates a search result and returns the total number of videos scraped """
+        """generates a search result and returns the total number of videos scraped"""
 
         page = 1
         while True:
@@ -266,7 +266,7 @@ class Ted2Zim:
         return total_videos_scraped
 
     def extract_videos_from_topics(self, topic):
-        """ extracts metadata for required number of videos on different topics """
+        """extracts metadata for required number of videos on different topics"""
 
         logger.debug(f"Fetching video links for topic: {topic}")
         topic_url = f"{self.talks_base_url}?topics%5B%5D={topic}"
@@ -324,7 +324,7 @@ class Ted2Zim:
                     self.description = f"A selection of {topic_str} videos from TED"
 
     def get_display_name(self, lang_code, lang_name):
-        """ Display name for language """
+        """Display name for language"""
 
         lang_info = get_language_details(lang_code, failsafe=True)
         if lang_code != "en" and lang_info:
@@ -350,7 +350,7 @@ class Ted2Zim:
         }
 
     def generate_subtitle_list(self, video_id, langs, page_lang, audio_lang):
-        """ List of all subtitle languages with link to their pages """
+        """List of all subtitle languages with link to their pages"""
 
         subtitles = []
         if self.subtitles_setting == ALL or (
@@ -385,7 +385,7 @@ class Ted2Zim:
         return update_subtitles_list(video_id, subtitles)
 
     def generate_urls_for_other_languages(self, url):
-        """ Possible URLs for other requested languages based on a video url """
+        """Possible URLs for other requested languages based on a video url"""
 
         urls = []
         page_lang, query = self.get_lang_code_from_url(url, with_full_query=True)
@@ -427,7 +427,7 @@ class Ted2Zim:
         return nb_extracted, nb_listed
 
     def get_lang_code_from_url(self, url, with_full_query=False):
-        """ gets the queried language code from a ted talk url """
+        """gets the queried language code from a ted talk url"""
 
         # sample - https://www.ted.com/talks/alex_rosenthal_the_gauntlet_think_like_a_coder_ep_8?language=ja
         url_parts = list(urllib.parse.urlparse(url))
@@ -440,7 +440,7 @@ class Ted2Zim:
         return current_lang
 
     def extract_download_link(self, talk_info):
-        """ Returns download link / youtube video ID for a TED video """
+        """Returns download link / youtube video ID for a TED video"""
 
         download_links = talk_info["downloads"]["nativeDownloads"]
         if download_links:
@@ -605,7 +605,7 @@ class Ted2Zim:
         )
 
     def extract_info_from_video_page(self, url, retry_count=0):
-        """ extract all info from a TED video page url and update self.videos """
+        """extract all info from a TED video page url and update self.videos"""
 
         # Every TED video page has a <script>-tag with a Javascript
         # object with JSON in it. We will just stip away the object
@@ -650,7 +650,7 @@ class Ted2Zim:
         return self.extract_video_info_from_json(json_data)
 
     def add_default_language(self):
-        """ add metatada in default language (english or first avail) on all videos """
+        """add metatada in default language (english or first avail) on all videos"""
 
         for video in self.videos:
             en_found = False
@@ -742,7 +742,7 @@ class Ted2Zim:
         )
 
     def generate_datafile(self):
-        """ Generate data.js inside assets folder """
+        """Generate data.js inside assets folder"""
 
         video_list = []
         for video in self.videos:
@@ -768,7 +768,7 @@ class Ted2Zim:
     def download_jpeg_image_and_convert(
         self, url, fpath, preset_options={}, resize=None
     ):
-        """ downloads a JPEG image and converts and optimizes it into desired format detected from fpath """
+        """downloads a JPEG image and converts and optimizes it into desired format detected from fpath"""
 
         org_jpeg_path = pathlib.Path(
             tempfile.NamedTemporaryFile(delete=False, suffix=".jpg").name
@@ -789,7 +789,7 @@ class Ted2Zim:
     def download_speaker_image(
         self, video_id, video_title, video_speaker, speaker_path
     ):
-        """ downloads the speaker image """
+        """downloads the speaker image"""
 
         downloaded_from_cache = False
         preset = WebpMedium()
@@ -817,7 +817,7 @@ class Ted2Zim:
     def download_thumbnail(
         self, video_id, video_title, video_thumbnail, thumbnail_path
     ):
-        """ download the thumbnail """
+        """download the thumbnail"""
 
         downloaded_from_cache = False
         preset = WebpMedium()
@@ -843,7 +843,7 @@ class Ted2Zim:
                     self.upload_to_cache(s3_key, thumbnail_path, preset.VERSION)
 
     def download_video_files(self, video):
-        """ download all video files (video, thumbnail, speaker) """
+        """download all video files (video, thumbnail, speaker)"""
 
         # Download all the TED talk videos and the meta-data for it.
         # Save the videos in build_dir/{video id}/video.mp4.
@@ -915,7 +915,7 @@ class Ted2Zim:
                 self.upload_to_cache(s3_key, req_video_file_path, preset.VERSION)
 
     def download_video_files_parallel(self):
-        """ download videos and images parallely """
+        """download videos and images parallely"""
 
         self.yt_downloader = YoutubeDownloader(threads=1)
         with concurrent.futures.ThreadPoolExecutor(
@@ -929,7 +929,7 @@ class Ted2Zim:
         self.yt_downloader.shutdown()
 
     def download_subtitles(self, index, video):
-        """ download, converts and writes VTT subtitles for a video at a specific index in self.videos """
+        """download, converts and writes VTT subtitles for a video at a specific index in self.videos"""
 
         # Download the subtitle files, generate a WebVTT file
         # and save the subtitles in
@@ -961,7 +961,7 @@ class Ted2Zim:
         self.videos[index]["subtitles"] = valid_subs
 
     def download_subtitles_parallel(self):
-        """ download subtitles for all videos parallely """
+        """download subtitles for all videos parallely"""
 
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=self.threads
@@ -987,7 +987,7 @@ class Ted2Zim:
         return True
 
     def download_from_cache(self, key, object_path, encoder_version):
-        """ whether it downloaded from S3 cache """
+        """whether it downloaded from S3 cache"""
 
         if self.use_any_optimized_version:
             if not self.s3_storage.has_object(key, self.s3_storage.bucket_name):
@@ -1007,7 +1007,7 @@ class Ted2Zim:
         return True
 
     def upload_to_cache(self, key, object_path, encoder_version):
-        """ whether it uploaded from S3 cache """
+        """whether it uploaded from S3 cache"""
 
         try:
             self.s3_storage.upload_file(
@@ -1020,7 +1020,7 @@ class Ted2Zim:
         return True
 
     def remove_failed_topics_and_check_extraction(self, failed_topics):
-        """ removes failed topics from topics list and raises error if scraper cannot continue """
+        """removes failed topics from topics list and raises error if scraper cannot continue"""
 
         for topic in failed_topics:
             self.topics.remove(topic)

--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -37,7 +37,7 @@ from .constants import (
     getLogger,
 )
 from .processing import post_process_video
-from .utils import WebVTT, download_link, update_subtitles_list
+from .utils import WebVTT, download_link, update_subtitles_list, get_main_title
 
 logger = getLogger()
 
@@ -143,9 +143,12 @@ class Ted2Zim:
             self.locale = setlocale(ROOT_DIR, locale_name)
         except locale.Error:
             logger.error(
-                f"No locale for {locale_name}. Use --locale to specify it. defaulting to en_US"
+                f"No locale for {locale_name}. Use --locale to specify it. "
+                "defaulting to en_US"
             )
             self.locale = setlocale(ROOT_DIR, "en")
+        # locale's language code
+        self.locale_name = self.to_ted_langcodes(locale_name)
 
     @property
     def templates_dir(self):
@@ -683,6 +686,7 @@ class Ted2Zim:
             loader=jinja2.FileSystemLoader(str(self.templates_dir)), autoescape=True
         )
         for video in self.videos:
+            titles = video["title"]
             html = env.get_template("article.html").render(
                 speaker=video["speaker"],
                 languages=video["subtitles"],
@@ -693,7 +697,8 @@ class Ted2Zim:
                 video_format=self.video_format,
                 autoplay=self.autoplay,
                 video_id=str(video["id"]),
-                titles=video["title"],
+                title=get_main_title(titles, self.locale_name),
+                titles=titles,
                 descriptions=video["description"],
                 back_to_list=_("Back to the list"),
             )

--- a/ted2zim/templates/article.html
+++ b/ted2zim/templates/article.html
@@ -5,7 +5,7 @@
         <meta content="utf-8" http-equiv="encoding">
         <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title id="title-head"></title>
+        <title id="title-head">{{ title }}</title>
         <link href="assets/videojs/video-js.min.css" rel="stylesheet" type="text/css">
         <link href="assets/article.css" rel="stylesheet" type="text/css">
         <link id="favicon" rel="shortcut icon" href="favicon.png" type="image/png">
@@ -17,7 +17,7 @@
         <script src="assets/jquery.min.js"></script>
         <script src="assets/article.js"></script>
         <script src="assets/polyfills.js"></script>
-        <script src="assets/webp-hero.bundle.js"></script>        
+        <script src="assets/webp-hero.bundle.js"></script>
     </head>
     <body>
         <div id="content">

--- a/ted2zim/templates/assets/article.js
+++ b/ted2zim/templates/assets/article.js
@@ -8,10 +8,7 @@ $.urlParam = function(name){
 
 window.onload = function() {
     var lang = $.urlParam('lang');
-    if (lang === "undefined") {
-        document.getElementById("title-head").innerHTML = $("p.title.lang-default").text();
-    }
-    else {
+    if (lang !== "undefined") {
         document.getElementById("title-head").innerHTML = $("p.title.lang-" + lang).text();
         $(".lang-default").css("display", "none");
         $(".lang-" + lang).css("display", "block");

--- a/ted2zim/utils.py
+++ b/ted2zim/utils.py
@@ -108,3 +108,21 @@ def get_temp_fpath(**kwargs):
         yield fpath
     finally:
         fpath.unlink()
+
+
+def get_main_title(titles, prefered_lang):
+    """ main title from list of titles dict based on language pref with fallback"""
+    missing = "n/a"
+    if not titles:
+        return missing
+
+    def get_for(lang):
+        filtered = [
+            title["text"]
+            for title in titles
+            if title["lang"] == lang
+        ]
+        if filtered:
+            return filtered[0]
+
+    return get_for(prefered_lang) or get_for("default") or get_for("en") or missing

--- a/ted2zim/utils.py
+++ b/ted2zim/utils.py
@@ -12,12 +12,12 @@ import requests
 
 
 def has_argument(arg_name, all_args):
-    """ whether --arg_name is specified in all_args """
+    """whether --arg_name is specified in all_args"""
     return list(filter(lambda x: x.startswith(f"--{arg_name}"), all_args))
 
 
 def update_subtitles_list(video_id, language_list):
-    """ adds `link` to each language dict containing the subtitle url """
+    """adds `link` to each language dict containing the subtitle url"""
 
     for language in language_list:
         language[
@@ -39,13 +39,13 @@ def download_link(url):
 
 class WebVTT:
 
-    """ TED JSON subtitles to WebVTT """
+    """TED JSON subtitles to WebVTT"""
 
     def __init__(self, url):
         self.url = url
 
     def convert(self):
-        """ download and convert its URL to WebVTT text """
+        """download and convert its URL to WebVTT text"""
         req = download_link(self.url)
 
         if req.status_code == 404:


### PR DESCRIPTION
Because ted2zim's UI is somewhat multilang, video pages contains a list of the retrieved titles for all the wanted languages.
A piece of JS uses the URL query language to set the <title>'s accordingly but the HTML source had no title, resulting in empty Title on ZIM entries (ted2zim is still using zimwriterfs-like mode).

Without changing this behavior, this sets the <title> to the *main* language's one. This language is chosen on --locale or defaults to video's default or English.

Suggestions do work now.