### PR TITLE
Update key for fetching speaker picture

### DIFF
--- a/ted2zim/scraper.py
+++ b/ted2zim/scraper.py
@@ -581,7 +581,7 @@ class Ted2Zim:
         video_id = json_data["id"]
         speaker_profession = speaker_info.get("description")
         speaker_bio = speaker_info.get("whoTheyAre", "-")
-        speaker_picture = speaker_info.get("avatar", "-")
+        speaker_picture = speaker_info.get("photoUrl", "-")
         title = json_data.get("title", "n/a")
         description = json_data.get("description", "n/a")
         date = dateutil.parser.parse(json_data["recordedOn"]).strftime("%d %B %Y")


### PR DESCRIPTION
fix #144 Sorry about the delay in this fix, had a busy week! Updated the key so the links for pictures can be fetched correctly. If there is no picture, the picture isn't shown already with the current code base. The reason it was the case earlier was because the presence of a picture is being done by checking for an empty string that refers to the photo path. With the correct key, the value ends up being '' which then is evaluated correctly. However, with the incorrect key, the value ended up being '-' which went through the check and then referred to a non-existent picture.