### PR TITLE
Fix fetching topics, moved to an internal search API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (as of version 2.0.11).
 
+## Unreleased
+
+### Changed
+- fixed search by topic to use new search API instead of broken web page scraping (#149)
+- download_link is renamed request_url and can also perform POST requests (in addition to previous GET requests)
+
 ## [2.0.13] - 2023-04-24
 
 ### Changed

--- a/ted2zim/constants.py
+++ b/ted2zim/constants.py
@@ -17,6 +17,8 @@ SCRAPER = f"{NAME} {VERSION}"
 
 BASE_URL = "https://ted.com/"
 
+SEARCH_URL = "https://zenith-prod-alt.ted.com/api/search"
+
 MATCHING = "matching"
 ALL = "all"
 NONE = "none"

--- a/ted2zim/multi/scraper.py
+++ b/ted2zim/multi/scraper.py
@@ -17,7 +17,7 @@ from zimscraperlib.logging import nicer_args_join
 from kiwixstorage import KiwixStorage
 
 from ..constants import NAME, getLogger
-from ..utils import download_link, get_temp_fpath
+from ..utils import request_url, get_temp_fpath
 
 logger = getLogger()
 
@@ -83,7 +83,7 @@ class TedHandler(object):
         for topic in topics_list:
             logger.debug(f"Getting playlists related to {topic}")
             playlist_sub_list = json.loads(
-                download_link(
+                request_url(
                     f"https://www.ted.com/playlists/browse.json?topics={topic['value'].replace(' ', '+')}"
                 ).text
             )
@@ -136,7 +136,7 @@ class TedHandler(object):
         """returns a list of topics or playlists"""
         # get all topics
         topics_list = json.loads(
-            download_link("https://www.ted.com/topics/combo?models=Talks").text
+            request_url("https://www.ted.com/topics/combo?models=Talks").text
         )
         if mode == "topic":
             return topics_list

--- a/ted2zim/utils.py
+++ b/ted2zim/utils.py
@@ -30,6 +30,13 @@ def update_subtitles_list(video_id, language_list):
 
 
 def request_url(url, json_data=None):
+    """performs an HTTP request and returns the response, either GET or POST
+    
+    - json_data is used as POST body when passed, otherwise a GET request is done
+    - request is retried 5 times, with a 30*attemp_no secs pause between retries
+    - a pause of 1 sec is done before every request (including first one)
+    """
+
     if url == f"{BASE_URL}playlists/57":
         url = f"{BASE_URL}playlists/57/björk_6_talks_that_are_music"
     for attempt in range(1, 6):


### PR DESCRIPTION
Fix #149 

# Changes
- move to an internal search API to find videos per topic
- enhance the utility method `download_link` to also perform POST requests needed by the search
- rewrite the filtering by language now that it is not available at search-time anymore when searching by topic
- topic names must not be URL-escaped anymore
- explicitly use the URL path to deduplicate videos (used only for playlists now)

Nota: code quality is obviously not optimal, I will fix it all at once with https://github.com/openzim/ted/issues/148 which will be done right after this is merged.