### PR TITLE
Enhance `extract_videos_in_search_results` to not fail on null `recordedOn` and log HTML content when parsing issue occurs

### DIFF
--- a/src/ted2zim/scraper.py
+++ b/src/ted2zim/scraper.py
@@ -581,7 +581,11 @@ class Ted2Zim:
         speaker_picture = speaker_info.get("photoUrl", "-")
         title = json_data.get("title", "n/a")
         description = json_data.get("description", "n/a")
-        date = dateutil.parser.parse(json_data["recordedOn"]).strftime("%d %B %Y")
+        date = (
+            dateutil.parser.parse(json_data["recordedOn"]).strftime("%d %B %Y")
+            if json_data.get("recordedOn")
+            else "Unknown"
+        )
         length = int(json_data["duration"]) // 60
         thumbnail = player_data["thumb"]
         video_link = self.extract_download_link(player_data)


### PR DESCRIPTION
## Rationale

Fix #161 
Close #163 (not really a fix, but should it reproduce again we will have more logs)

## Changes

- when `recordedOn` property of video JSON data  is null, use "Unknown" as date value (we need a string to display in the UI)
- log HTML content of video page when a parsing issue occurs, so that debugging is more straightforward