### PR TITLE
Restore and enhance Youtube download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ RUN apt-get update \
  && python -m pip install --no-cache-dir -U \
       pip
 
+# Custom entrypoint
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+
 # Copy pyproject.toml and its dependencies
 COPY pyproject.toml README.md hatch_build.py get_js_deps.sh /src/
 COPY src/ted2zim/__about__.py /src/src/ted2zim/__about__.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "Attempting to update yt-dlp…"
+pip3 install -U yt-dlp
+
+
+exec "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
   "kiwixstorage==0.8.3",
   "pif==0.8.2",
   "python-slugify==8.0.1",
+  "yt-dlp", # yt-dlp should be updated as frequently as possible
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION

## Rationale

Fix #167 
Fix #164 

## Changes

- use yt_dlp instead of youtube_dlp which is not updated anymore
- update continuously yt_dlp (at each build + each container startup)
- restore support of youtube ID
- support both video_link and youtube ID, try first the video link (if provided) and then fallback to youtube ID
- do not create an empty ZIM
- do not add videos which have not been downloaded to the ZIM
