### PR TITLE
add support for grabbing all videos if languages is not set

### DIFF
--- a/src/ted2zim/scraper.py
+++ b/src/ted2zim/scraper.py
@@ -185,7 +185,7 @@ class Ted2Zim:
         self.source_languages = (
             [] if not self.languages else self.to_ted_langcodes(self.languages)
         )
-        self.already_visited = []
+        self.already_visited = set()
 
         # set and record locale for translations
         locale_details = get_language_details(locale_name)
@@ -291,38 +291,49 @@ class Ted2Zim:
         for element in video_elements:
             relative_path = element.get("href")
             url = urllib.parse.urljoin(self.talks_base_url, relative_path)
-            ok, json_data = self.extract_info_from_video_page(url)
+            json_data = self.extract_info_from_video_page(url)
 
-            if (
-                ok
-                and json_data is not None
-                and self.update_videos_list_from_info(json_data)
-            ):
+            if json_data is not None and self.update_videos_list_from_info(json_data):
+                lang_code = json_data["language"]
                 if self.source_languages:
-                    other_lang_urls = self.generate_urls_for_other_languages(
-                        url, self.source_languages
-                    )
+                    # Determine the next languages to fetch from source_languages
+                    other_languages = []
+                    for language_code in self.source_languages:
+                        # Do not include the language that was just scraped
+                        if language_code == lang_code:
+                            continue
+                        other_languages.append(language_code)
                 else:
                     # No languages were specified. We use the the languages returned
-                    # from the json_data of this video to generate other language urls
-                    available_languages = [
-                        language["languageCode"]
-                        for language in json_data["playerData"]["languages"]
-                    ]
-                    other_lang_urls = self.generate_urls_for_other_languages(
-                        url, available_languages
-                    )
+                    # from the json_data of this video to generate other language urls.
+                    other_languages = []
+                    for language in json_data["playerData"]["languages"]:
+                        # Do not include the language of the video that
+                        # was just scraped
+                        if language["languageCode"] == lang_code:
+                            continue
+                        other_languages.append(language["languageCode"])
+
+                if not other_languages:
+                    # No need to generate urls for other languages as the list
+                    # is empty
+                    self.already_visited.add(urllib.parse.urlparse(url).path)
+                    continue
+
+                other_lang_urls = self.generate_urls_for_other_languages(
+                    url, other_languages
+                )
 
                 logger.debug(
                     f"Searching info for the video in other {len(other_lang_urls)} "
                     "language(s)"
                 )
                 for lang_url in other_lang_urls:
-                    ok, data = self.extract_info_from_video_page(lang_url)
-                    if ok and data is not None:
+                    data = self.extract_info_from_video_page(lang_url)
+                    if data is not None:
                         self.update_videos_list_from_info(data)
 
-                self.already_visited.append(urllib.parse.urlparse(url).path)
+                self.already_visited.add(urllib.parse.urlparse(url).path)
             logger.debug(f"Seen {relative_path}")
         logger.debug(f"Total videos found on playlist: {len(video_elements)}")
         if not video_elements:
@@ -487,65 +498,78 @@ class Ted2Zim:
         logger.debug(f"{nb_listed} video(s) found on current page")
         for hit in hits:
             url = urllib.parse.urljoin(self.talks_base_url, hit["slug"])
-            ok, json_data = self.extract_info_from_video_page(url)
-            if ok and json_data is not None:
-                lang_code, _ = self.get_lang_code_and_name(json_data)
-                player_data = json_data["playerData"]
-                # we need to filter videos since this has not been done
-                # before for topics with the "new" search page (2023)
-                if self.source_languages:
-                    if lang_code not in self.source_languages:
-                        # video language is not among the selected ones,
-                        # we have to check subtitles if they are enough
-                        if not self.subtitles_enough:
+            json_data = self.extract_info_from_video_page(url)
+
+            if json_data is None:
+                continue
+
+            lang_code = json_data["language"]
+            player_data = json_data["playerData"]
+            # we need to filter videos since this has not been done
+            # before for topics with the "new" search page (2023)
+            if self.source_languages:
+                if lang_code not in self.source_languages:
+                    # video language is not among the selected ones,
+                    # we have to check subtitles if they are enough
+                    if not self.subtitles_enough:
+                        logger.debug(
+                            f"Ignoring video in non-selected language {lang_code}"
+                        )
+                        continue
+                    else:
+                        matching_languages = [
+                            lang
+                            for lang in player_data["languages"]
+                            if lang["languageCode"] in self.source_languages
+                        ]
+                        if len(matching_languages) == 0:
                             logger.debug(
-                                f"Ignoring video in non-selected language {lang_code}"
+                                "Ignoring video without a selected language in "
+                                "audio or subtitles"
                             )
                             continue
-                        else:
-                            matching_languages = [
-                                lang
-                                for lang in player_data["languages"]
-                                if lang["languageCode"] in self.source_languages
-                            ]
-                            if len(matching_languages) == 0:
-                                logger.debug(
-                                    "Ignoring video without a selected language in "
-                                    "audio or subtitles"
-                                )
-                                continue
-                    if self.update_videos_list_from_info(json_data):
+                if self.update_videos_list_from_info(json_data):
+                    nb_extracted += 1
+            else:
+                # Since we are searching for all languages, first update the
+                # videos list with the data we just scraped.
+                if self.update_videos_list_from_info(json_data):
+                    nb_extracted += 1
+
+                # We use the the languages returned from the json_data of
+                # this video to generate other language urls
+                other_languages = []
+                for language in json_data["playerData"]["languages"]:
+                    #  Do not include the language of the video that was just scraped
+                    if language["languageCode"] == lang_code:
+                        continue
+                    other_languages.append(language["languageCode"])
+
+                if not other_languages:
+                    # No need to generate urls for other languages as the list
+                    # is empty
+                    self.already_visited.add(urllib.parse.urlparse(url).path)
+                    continue
+
+                other_lang_urls = self.generate_urls_for_other_languages(
+                    url, other_languages
+                )
+                logger.debug(
+                    f"Searching info for the video in other {len(other_lang_urls)} "
+                    "language(s)"
+                )
+                for lang_url in other_lang_urls:
+                    data = self.extract_info_from_video_page(lang_url)
+                    if data is not None and self.update_videos_list_from_info(data):
+                        # Despite that we are making a call to update
+                        # the videos list, only the first unique video_id
+                        # causes nb_extracted to be incremented. Other
+                        # calls simply update the metadata of the
+                        # video.
                         nb_extracted += 1
-                else:
-                    # No languages were specified. We use the the languages returned
-                    # from the json_data of this video to generate other language urls
-                    available_languages = [
-                        language["languageCode"]
-                        for language in player_data["languages"]
-                    ]
-                    other_lang_urls = self.generate_urls_for_other_languages(
-                        url, available_languages
-                    )
-                    logger.debug(
-                        f"Searching info for the video in other {len(other_lang_urls)} "
-                        "language(s)"
-                    )
-                    for lang_url in other_lang_urls:
-                        ok, data = self.extract_info_from_video_page(lang_url)
-                        if (
-                            ok
-                            and data is not None
-                            and self.update_videos_list_from_info(data)
-                        ):
-                            # Despite that we are making a call to update
-                            # the videos list, only the first unique video_id
-                            # causes nb_extracted to be incremented. Other
-                            # calls simply update the metadata of the
-                            # video.
-                            nb_extracted += 1
 
             logger.debug(f"Seen {hit['slug']}")
-            self.already_visited.append(urllib.parse.urlparse(url).path)
+            self.already_visited.add(urllib.parse.urlparse(url).path)
         return nb_extracted, nb_listed
 
     def get_lang_code_from_url(self, url, *, with_full_query=False):
@@ -766,11 +790,12 @@ class Ted2Zim:
             subtitles=subtitles,
         )
 
-    def extract_info_from_video_page(self, url, retry_count=0):
-        """extract all info from a TED video page url. Returns a 2-element
-        tuple where the first element is a boolean indicating if the
-        search was successful and the second element is the payload
-        containing the video info or None if the search was not successful.
+    def extract_info_from_video_page(
+        self, url: str, retry_count: int = 0
+    ) -> dict | None:
+        """extract all info from a TED video page url.
+        Returns a dict containign the video information if search was
+        successful, else None.
         """
 
         # Every TED video page has a <script>-tag with a Javascript
@@ -780,12 +805,12 @@ class Ted2Zim:
 
         # don't scrape if URL already visited
         if urllib.parse.urlparse(url).path in self.already_visited:
-            return False, None
+            return None
 
         # don't scrape if maximum retry count is reached
         if retry_count > 5:  # noqa: PLR2004
             logger.error("Max retries exceeded. Skipping video")
-            return False, None
+            return None
 
         logger.debug(f"extract_info_from_video_page: {url}")
         html_content = request_url(url).text
@@ -803,12 +828,11 @@ class Ted2Zim:
                 logger.error(
                     f"Video has not yet been translated into {requested_lang_code}"
                 )
-                return False, None
-            # Serialize the data at json_data["playerData"] into a dict
+                return None
+            # Desrialize the data at json_data["playerData"] into a dict
             # and overwrite it accordingly
-            player_data = json.loads(json_data["playerData"])
-            json_data["playerData"] = player_data
-            return True, json_data
+            json_data["playerData"] = json.loads(json_data["playerData"])
+            return json_data
         except Exception:
             logger.error(
                 f"Problem occured while parsing {url}. HTML content was:\n"

--- a/src/ted2zim/scraper.py
+++ b/src/ted2zim/scraper.py
@@ -305,8 +305,10 @@ class Ted2Zim:
                         code for code in self.source_languages if code != lang_code
                     ]
                 else:
-                    # No languages were specified. We use the the languages returned
-                    # from the json_data of this video to generate other language urls.
+                    # No languages were specified. Save the first video
+                    self.update_videos_list_from_info(json_data)
+                    # We use the the languages returned from the first
+                    # video to generate other language urls.
                     other_languages = [
                         language["languageCode"]
                         for language in player_data["languages"]
@@ -672,9 +674,6 @@ class Ted2Zim:
                     "youtube_id": youtube_id,
                     "length": length,
                     "subtitles": subtitles,
-                    "subtitles_set": {
-                        subtitle["languageCode"] for subtitle in subtitles
-                    },
                 }
             )
             logger.debug(f"Successfully inserted video {video_id} into video list")
@@ -700,20 +699,9 @@ class Ted2Zim:
                             "languageName": self.get_display_name(lang_code, lang_name),
                         }
                     )
-                if self.subtitles_setting in (MATCHING, NONE):
-                    # Only add subtitles which have not been added to avoid
-                    # duplicates
-                    new_subtitles = [
-                        subtitle
-                        for subtitle in subtitles
-                        if subtitle["languageCode"]
-                        not in self.videos[index]["subtitles_set"]
-                    ]
-                    self.videos[index]["subtitles"] += new_subtitles
-                    for subtitle in new_subtitles:
-                        self.videos[index]["subtitles_set"].add(
-                            subtitle["languageCode"]
-                        )
+
+                if self.subtitles_setting in (MATCHING, NONE) and len(subtitles) == 1:
+                    self.videos[index]["subtitles"] += subtitles
         return False
 
     def get_lang_code_and_name(self, json_data):


### PR DESCRIPTION
Fix #171

## Rationale
When `--languages` is omitted from the command-line arguments, the scraper should search for all available languages of that particular video and add it to the videos list.

<!--
Mention fixed issues that will be closed automatically with some "Fix #xxx"
-->

## Changes
- Refactor the method `extract_info_from_video_page` to return a 2-element tuple of shape `(bool, video_json_data)` and use the information in this json data to fetch more languages if `source_languages` is empty (which implies `--languages` was not set).
- Refactor `generate_urls_for_other_languages` to take a language list instead of the internal `self.source_languages`. This way, we can generate urls for all the languages obtained from the video information.
- Rename the function `extract_video_info_from_json` to `update_videos_list_from_info` as that is what it actually does. Then, move the logic for filtering `self.topics` to the function `extract_videos_from_search_results` as that is the only place where `topics` are actually searched. This way, the function `update_videos_list_from_info` does only one thing described by its name.
- Filter out duplicate subtitles