### PR TITLE
fix issue with sort_language_hack returning None

### DIFF
--- a/src/ted2zim/scraper.py
+++ b/src/ted2zim/scraper.py
@@ -106,24 +106,20 @@ class Ted2Zim:
             For now, if eng is among the list, we assume it is the most important
             language. Otherwise list is kept as-is
             """
-            return list(languages).sort(
-                key=lambda x: -1 if x == "eng" else 0
-            )  # pyright: ignore[reportReturnType]
+            return sorted(languages, key=lambda x: -1 if x == "eng" else 0)
 
         if not self.languages:
             self.zim_languages = "eng"
         else:
-            self.zim_languages = ",".join(
-                sort_languages_hack(
-                    {
-                        lang
-                        for lang in [
-                            get_iso_639_3_language(lang) for lang in self.languages
-                        ]
-                        if lang
-                    }
-                )
-            )
+            languages_set = {
+                lang
+                for lang in [get_iso_639_3_language(lang) for lang in self.languages]
+                if lang
+            }
+            if not languages_set:
+                self.zim_languages = "eng"
+            else:
+                self.zim_languages = ",".join(sort_languages_hack(languages_set))
         self.tags = [] if tags is None else [tag.strip() for tag in tags.split(",")]
         self.tags = [*self.tags, "_category:ted", "ted", "_videos:yes"]
         self.title = title

--- a/src/ted2zim/scraper.py
+++ b/src/ted2zim/scraper.py
@@ -108,18 +108,21 @@ class Ted2Zim:
             """
             return sorted(languages, key=lambda x: -1 if x == "eng" else 0)
 
-        if not self.languages:
+        self.zim_languages = ",".join(
+            sort_languages_hack(
+                {
+                    lang
+                    for lang in [
+                        get_iso_639_3_language(lang) for lang in self.languages
+                    ]
+                    if lang
+                }
+            )
+        )
+
+        if not self.zim_languages:
             self.zim_languages = "eng"
-        else:
-            languages_set = {
-                lang
-                for lang in [get_iso_639_3_language(lang) for lang in self.languages]
-                if lang
-            }
-            if not languages_set:
-                self.zim_languages = "eng"
-            else:
-                self.zim_languages = ",".join(sort_languages_hack(languages_set))
+
         self.tags = [] if tags is None else [tag.strip() for tag in tags.split(",")]
         self.tags = [*self.tags, "_category:ted", "ted", "_videos:yes"]
         self.title = title


### PR DESCRIPTION
## Rationale
When run with `--languages` flag, the scraper throws an error
```
 self.zim_languages = ",".join(
                         ^^^^^^^^^
TypeError: can only join an iterable
```
This is because the `list.sort` method returns None as it sorts the list in place.
```
            return list(languages).sort(
                key=lambda x: -1 if x == "eng" else 0
            )  # pyright: ignore[reportReturnType]
```
[//]: # (Briefly explain the reason behind this change.)

<!--
Mention fixed issues that will be closed automatically with some "Fix #xxx"
-->

## Changes
- Use the `sorted` function which returns a list instead rather than the `list.sort` which returns `None`.
- Check for the possibility that after sorting, the languages set might still be empty, in which case, set `zim_language` to `eng`