### PR TITLE
Populate the real list of languages in ZIM metadata

### DIFF
--- a/src/ted2zim/languages.py
+++ b/src/ted2zim/languages.py
@@ -1,0 +1,89 @@
+from zimscraperlib.i18n import get_language_details
+
+from ted2zim.constants import (
+    TEDLANGS,
+    get_logger,
+)
+
+logger = get_logger()
+
+
+def get_display_name(lang_code, lang_name):
+    """Display name for language"""
+
+    lang_info = get_language_details(lang_code, failsafe=True)
+    if lang_code != "en" and lang_info:
+        return lang_info["native"] + " - " + lang_name
+    return lang_name
+
+
+def append_part1_or_part3(lang_code_list, lang_info):
+    """Fills missing ISO languages codes for all in list
+
+    lang_code_list: list og lang codes
+    lang_info: see zimscraperlib.i18n"""
+
+    # ignore extra language mappings if supplied query was an iso-639-1 code
+    if "part1" in lang_info["iso_types"]:
+        lang_code_list.append(lang_info["iso-639-1"])
+
+    # supplied query was not iso-639-1
+    elif lang_info["iso-639-1"]:
+        lang_code_list.append(lang_info["iso-639-1"])
+        # check for extra language codes to include
+        if lang_info["iso-639-1"] in TEDLANGS["mappings"]:
+            for code in TEDLANGS["mappings"][lang_info["iso-639-1"]]:
+                lang_code_list.append(code)
+    elif lang_info["iso-639-3"]:
+        lang_code_list.append(lang_info["iso-639-3"])
+    else:
+        supplied_lang = lang_info["query"]
+        logger.error(f"Language {supplied_lang} is not supported by TED")
+
+
+def to_ted_langcodes(languages):
+    """Converts languages queries into TED language codes
+
+    Examples:
+        ["English", "fr", "hin"] => ["en", "fr", "hi"]
+        ["chi", "fake"] => ["zh", "zh-cn", "zh-tw"]
+    """
+
+    lang_code_list = []
+    for lang in languages:
+        lang_info = get_language_details(lang, failsafe=True)
+        if lang_info:
+            logger.warning(lang_info)
+            if lang_info["querytype"] == "purecode":
+                append_part1_or_part3(lang_code_list, lang_info)
+            elif lang_info["querytype"] == "locale":
+                query = lang_info["query"].replace("_", "-")
+                if query in TEDLANGS["locales"]:
+                    lang_code_list.append(query)
+                else:
+                    append_part1_or_part3(lang_code_list, lang_info)
+            else:
+                append_part1_or_part3(lang_code_list, lang_info)
+    return list(set(lang_code_list))
+
+
+def ted_to_iso639_3_langcodes(ted_langcodes):
+    """Create a mapping of TED language codes to ISO639-3
+
+    Returns a mapping dictionary of TED codes to converted ISO639-3 codes, when ISO code
+    does not exist, dictionary value is "None".
+
+
+    Examples:
+        ["zh", "zh-cn", "zh-tw"] => {"zh": "chi", "zh-cn": "chi", "zh-tw": "chi"}
+    """
+
+    mapping = {}
+    for lang in set(ted_langcodes):
+        lang_info = get_language_details(lang, failsafe=True)
+        if lang_info and lang_info["iso-639-3"]:
+            mapping[lang] = lang_info["iso-639-3"]
+        else:
+            mapping[lang] = None
+
+    return mapping

--- a/src/ted2zim/languages.py
+++ b/src/ted2zim/languages.py
@@ -20,7 +20,7 @@ def get_display_name(lang_code, lang_name):
 def append_part1_or_part3(lang_code_list, lang_info):
     """Fills missing ISO languages codes for all in list
 
-    lang_code_list: list og lang codes
+    lang_code_list: list of lang codes
     lang_info: see zimscraperlib.i18n"""
 
     # ignore extra language mappings if supplied query was an iso-639-1 code
@@ -53,7 +53,6 @@ def to_ted_langcodes(languages):
     for lang in languages:
         lang_info = get_language_details(lang, failsafe=True)
         if lang_info:
-            logger.warning(lang_info)
             if lang_info["querytype"] == "purecode":
                 append_part1_or_part3(lang_code_list, lang_info)
             elif lang_info["querytype"] == "locale":

--- a/src/ted2zim/scraper.py
+++ b/src/ted2zim/scraper.py
@@ -166,7 +166,7 @@ class Ted2Zim:
             )
             self.locale = setlocale(ROOT_DIR, "en")
         # locale's language code
-        self.locale_name = tedlang.to_ted_langcodes(locale_name)
+        self.locale_ted_codes = tedlang.to_ted_langcodes(locale_name)
 
     @property
     def templates_dir(self):
@@ -891,7 +891,7 @@ class Ted2Zim:
                 video_format=self.video_format,
                 autoplay=self.autoplay,
                 video_id=str(video["id"]),
-                title=get_main_title(titles, self.locale_name),
+                title=get_main_title(titles, self.locale_ted_codes),
                 titles=titles,
                 descriptions=video["description"],
                 back_to_list=_("Back to the list"),

--- a/src/ted2zim/scraper.py
+++ b/src/ted2zim/scraper.py
@@ -345,16 +345,16 @@ class Ted2Zim:
 
         # count the number of videos per audio language
         audio_lang_counts = {
-            k: len(list(g))
-            for k, g in groupby(
+            lang: len(list(group))
+            for lang, group in groupby(
                 [video["native_talk_language"] for video in self.videos]
             )
         }
 
         # count the number of videos per subtitle language
         subtitle_lang_counts = {
-            k: len(list(g))
-            for k, g in groupby(
+            lang: len(list(group))
+            for lang, group in groupby(
                 [
                     subtitle["languageCode"]
                     for video in self.videos
@@ -371,12 +371,13 @@ class Ted2Zim:
         }
 
         sorted_ted_languages = [
-            item[0]
-            for item in sorted(scored_languages.items(), key=lambda item: -item[1])
+            lang_code
+            for lang_code, _ in sorted(
+                scored_languages.items(), key=lambda item: -item[1]
+            )
         ]
 
         # compute the mappings from TED to ISO639-3 code and set ZIM language
-        # (mapping is usefull to keep list in same order)
         mapping = tedlang.ted_to_iso639_3_langcodes(sorted_ted_languages)
         self.zim_languages = ",".join(
             [mapping[code] for code in sorted_ted_languages if mapping[code]]

--- a/src/ted2zim/templates/assets/article.js
+++ b/src/ted2zim/templates/assets/article.js
@@ -8,7 +8,7 @@ $.urlParam = function(name){
 
 window.onload = function() {
     var lang = $.urlParam('lang');
-    if (lang !== "undefined") {
+    if (lang && lang !== "undefined") {
         document.getElementById("title-head").innerHTML = $("p.title.lang-" + lang).text();
         $(".lang-default").css("display", "none");
         $(".lang-" + lang).css("display", "block");

--- a/src/ted2zim/utils.py
+++ b/src/ted2zim/utils.py
@@ -148,15 +148,20 @@ def get_temp_fpath(**kwargs):
             fpath.unlink()
 
 
-def get_main_title(titles, prefered_lang):
+def get_main_title(titles, locale_ted_codes: list[str]):
     """main title from list of titles dict based on language pref with fallback"""
     missing = "n/a"
     if not titles:
         return missing
 
-    def get_for(lang):
+    def get_for(lang: str):
         filtered = [title["text"] for title in titles if title["lang"] == lang]
         if filtered:
             return filtered[0]
 
-    return get_for(prefered_lang) or get_for("default") or get_for("en") or missing
+    for code in [*locale_ted_codes, "default", "en"]:
+        title = get_for(code)
+        if title:
+            return title
+
+    return missing

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,0 +1,75 @@
+import pytest
+
+from ted2zim import languages as tedlang
+
+
+@pytest.mark.parametrize(
+    "input_languages,expected_languages",
+    [
+        pytest.param(["English", "fr", "hin"], ["en", "fr", "hi"], id="simple"),
+        pytest.param(["chi"], ["zh", "zh-cn", "zh-tw"], id="chinese"),
+        pytest.param(["Portuguese"], ["pt", "pt-br"], id="portuguese"),
+        pytest.param(["de_AT"], ["de"], id="austria"),
+        pytest.param(["pt-br"], ["pt-br"], id="brazilian"),
+        pytest.param(["alg"], [], id="missing_iso_639_3"),
+        pytest.param(["fake"], [], id="not_existing"),
+        pytest.param(
+            ["English", "fr", "hin", "chi", "fake"],
+            ["en", "fr", "hi", "zh", "zh-cn", "zh-tw"],
+            id="full",
+        ),
+    ],
+)
+def test_to_ted_languages(input_languages, expected_languages):
+    # we compare sets since order is not relevant
+    assert set(tedlang.to_ted_langcodes(input_languages)) == set(expected_languages)
+
+
+@pytest.mark.parametrize(
+    "input_languages,expected_mapping",
+    [
+        pytest.param(
+            ["en", "fr", "hi"], {"en": "eng", "fr": "fra", "hi": "hin"}, id="simple"
+        ),
+        pytest.param(
+            ["zh", "zh-cn", "zh-tw"],
+            {"zh": "zho", "zh-cn": "zho", "zh-tw": "zho"},
+            id="chinese",
+        ),
+        pytest.param(["pt", "pt-br"], {"pt": "por", "pt-br": "por"}, id="portuguese"),
+        pytest.param(["de_AT"], {"de_AT": "deu"}, id="austria"),
+        pytest.param(["alg"], {"alg": None}, id="missing_iso_639_3"),
+        pytest.param(["fake"], {"fake": None}, id="not_existing"),
+        pytest.param(
+            [
+                "en",
+                "fr",
+                "hi",
+                "zh",
+                "zh-cn",
+                "zh-tw",
+                "pt",
+                "pt-br",
+                "de_AT",
+                "alg",
+                "fake",
+            ],
+            {
+                "en": "eng",
+                "fr": "fra",
+                "hi": "hin",
+                "zh": "zho",
+                "zh-cn": "zho",
+                "zh-tw": "zho",
+                "de_AT": "deu",
+                "pt": "por",
+                "pt-br": "por",
+                "alg": None,
+                "fake": None,
+            },
+            id="full",
+        ),
+    ],
+)
+def test_ted_to_iso639_3_langcodes(input_languages, expected_mapping):
+    assert tedlang.ted_to_iso639_3_langcodes(input_languages) == expected_mapping


### PR DESCRIPTION
## Rationale

Fix #172 

## Changes

- moved all lang related functions to languages.py
- added few tests for existing conversion from input languages to TED code
- added new function to convert back TED code to ISO639-3 code
- added code to compute ZIM languages (twice, asap to avoid downloading videos if we know there is a metadata issue and later once the final list of downloaded videos is known)
- better handle case when opening the video page with the `lang` queryparameter not set