### PR TITLE
Fetch real subtitle offset and default to 0

### DIFF
--- a/src/ted2zim/utils.py
+++ b/src/ted2zim/utils.py
@@ -80,7 +80,7 @@ class WebVTT:
     def __init__(self, url):
         self.url = url
 
-    def convert(self):
+    def convert(self, offset):
         """download and convert its URL to WebVTT text"""
         req = request_url(self.url)
 
@@ -91,7 +91,7 @@ class WebVTT:
         except json.JSONDecodeError:
             return None
 
-        return self.json_to_vtt(source_subtitles)
+        return self.json_to_vtt(source_subtitles, offset)
 
     @staticmethod
     def miliseconds_to_human(miliseconds):
@@ -105,7 +105,7 @@ class WebVTT:
         return f"{hours:02}:{minutes:02}:{seconds:02}.{miliseconds:03}"
 
     @staticmethod
-    def json_to_vtt(json_subtitles, offset=11820):
+    def json_to_vtt(json_subtitles, offset):
         """WebVTT string from TED JSON subtitles list
 
         TED format: {"captions": [


### PR DESCRIPTION
## Rationale

Fix #177 

## Changes

- remove the default 11820 ms offset from many many years ago and default to 0 ms
- try to fetch video metadata where the subtitle offset is present 
  - see e.g. https://hls.ted.com/project_masters/1140/metadata.json?intro_master_id=2346