### PR TITLE
Add playsinline attribute to video

### DIFF
--- a/src/ted2zim/templates/article.html
+++ b/src/ted2zim/templates/article.html
@@ -28,7 +28,7 @@
             {% endfor %}
             <div id="video-wrapper">
                 <video class="video-js vjs-default-skin vjs-fill"
-                    controls preload="auto"
+                    controls preload="auto" playsinline
                     poster="videos/{{ video_id }}/thumbnail.webp"
                     data-setup='{"techOrder": ["html5", "ogvjs"], "ogvjs": {"base": "assets/ogvjs"}, "autoplay": {% if autoplay %}true{% else %}false{% endif %}, "preload": true, "controls": true, "controlBar": {"pictureInPictureToggle":false}}'>
                     <source src="videos/{{ video_id }}/video.{{ video_format }}" type="video/{{ video_format }}" />


### PR DESCRIPTION

## Rationale

This is meant to enhance the support of Safari browser, where when the video starts in fullscreen there are rendering issues on some Safari / OS versions. This is clearly a workaround but it does not hurt at all.

Together with the updated video encoder settings coming from updated zimscraperlib, this should enhance very significantly Safari support and hence allow to close the issue. Should anymore concern appear, we will have to open new, dedicated and precise issues.

Fix #145 

## Changes

- add `playsinline` to `<video>` HTML5 tag, so that the video does not plays in fullscreen automatically