### PR TITLE
Missing translation is not an error, only a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Change log level from ERROR to WARNING for missing translations (#197)
+
 ## [3.0.0] - 2024-04-19
 
 ### Added

--- a/src/ted2zim/scraper.py
+++ b/src/ted2zim/scraper.py
@@ -829,8 +829,9 @@ class Ted2Zim:
 
             requested_lang_code = self.get_lang_code_from_url(url)
             if requested_lang_code and json_data["language"] != requested_lang_code:
-                logger.error(
-                    f"Video has not yet been translated into {requested_lang_code}"
+                logger.warning(
+                    f"Video at {url} has not yet been translated into "
+                    f"{requested_lang_code}"
                 )
                 return None
             # Desrialize the data at json_data["playerData"] into a dict


### PR DESCRIPTION
## Rationale

Log level indicating that a translation is missing was output as ERROR, while it should probably be a WARNING since it happens quite a significant amount of time and the scraper is perfectly capable to cope with it (i.e. it won't cause any visible bug on the final ZIM, and it is usually linked to inconsistency in TED data).