### PR TITLE
Fix HTTP retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Change log level from ERROR to WARNING for missing translations (#197)
+- Fix HTTP retries to consider any HTTP failure, not only bad HTTP status code (#162)
 
 ## [3.0.0] - 2024-04-19
 

--- a/src/ted2zim/utils.py
+++ b/src/ted2zim/utils.py
@@ -38,19 +38,19 @@ def request_url(url, json_data=None):
         url = f"{BASE_URL}playlists/57/björk_6_talks_that_are_music"
     max_attempts, attempt = 5, 1
     while True:
-        time.sleep(1)  # delay requests
-        if json_data:
-            req = requests.post(
-                url,
-                headers={"User-Agent": "Mozilla/5.0"},
-                json=json_data,
-                timeout=REQUESTS_TIMEOUT,
-            )
-        else:
-            req = requests.get(
-                url, headers={"User-Agent": "Mozilla/5.0"}, timeout=REQUESTS_TIMEOUT
-            )
         try:
+            time.sleep(1)  # delay requests
+            if json_data:
+                req = requests.post(
+                    url,
+                    headers={"User-Agent": "Mozilla/5.0"},
+                    json=json_data,
+                    timeout=REQUESTS_TIMEOUT,
+                )
+            else:
+                req = requests.get(
+                    url, headers={"User-Agent": "Mozilla/5.0"}, timeout=REQUESTS_TIMEOUT
+                )
             req.raise_for_status()
             return req
         except Exception as exc:


### PR DESCRIPTION
## Rationale

Fix #162 

## Changes

- the try/catch logic used to retry HTTP call was only taking care of bad HTTP status code, while indeed we are far more interested in retrying connection issues (timeout mostly, but also intermittent DNS issues, ...)