### PR TITLE
retry video info extract on missing videoData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -  Restore functionality to resist temporary bad TED responses when parsing video pages (#209)
+-  Retry video data extraction if `videoData` is missing from page data (#226)
 
 ## [3.0.2] - 2024-06-24
 


### PR DESCRIPTION
## Rationale
Sometimes, `videoData` is missing in the `__NEXT_DATA__` data returned from the edX page. This PR retries such requests rather than throwing an error.

<!--
Mention fixed issues that will be closed automatically with some "Fix #xxx"
-->
This resolves #222 

## Changes
- Catch the `KeyError` thrown when accessing the `videoData` and retry request
- Add exception message to log output in outer exception handler in `extract_info_from_video_page`