### PR TITLE
change message on missing language data for video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change log level of "Video at {url} has not yet been translated into {requested_lang_code}" messages from warning to debug (way too verbose)
 - Disable preloading of subtitles in video.js
+- Change warning message when language data is missing from video (#216)
 
 ### Fixed
 

--- a/src/ted2zim/scraper.py
+++ b/src/ted2zim/scraper.py
@@ -707,8 +707,11 @@ class Ted2Zim:
                 for lang in player_data["languages"]
                 if lang["languageCode"] == lang_code
             ][-1]
-        except Exception as exc:
-            logger.warning(f"player data has no entry for {lang_code}: {exc}")
+        except Exception:
+            logger.warning(
+                f"Video at {json_data.get('canonicalUrl')} "
+                f"has no subtitle/language data in {lang_code}"
+            )
             lang_name = lang_code
 
         return lang_code, lang_name


### PR DESCRIPTION
## Rationale
Sometimes, even though a video exists for a particular native language, there is no available subtitle/language data for the video in that language. This PR re-words the warning message to a more descriptive message. This resolves #216.


## Changes
- Fetch video url using it's canonical url and build up warning message. The `get` attribute is used as we are in an exception handler and using the `[]` to access the canonical url might throw an error given this data is from an external API and we don't want to throw an exception from here.
