### PR TITLE
skip download of speaker image if url is "-"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -  Restore functionality to resist temporary bad TED responses when parsing video pages (#209)
 -  Retry video data extraction if `videoData` is missing from page data (#226)
+-  Skip download of speaker image if URL is "-" (#224)
 
 ## [3.0.2] - 2024-06-24
 

--- a/src/ted2zim/scraper.py
+++ b/src/ted2zim/scraper.py
@@ -1033,9 +1033,15 @@ class Ted2Zim:
             )
         if not downloaded_from_cache:
             try:
-                # download an image of the speaker
+                # Before downloading a speaker image, check if the URL exists.
+                # Sometimes, the URL from TED is "-" which is invalid.
                 if not video_speaker:
                     logger.debug("Speaker doesn't have an image")
+                elif video_speaker == "-":
+                    logger.error(
+                        f"Invalid speaker image URL {video_speaker!r} for "
+                        f"{video_title}"
+                    )
                 else:
                     logger.debug(f"Downloading Speaker image for {video_title}")
                     self.download_jpeg_image_and_convert(


### PR DESCRIPTION
## Rationale
Sometimes, speaker image URLs are invalid and causes the scraper to throw errors after attempting to fetch the resource. This PR ensures the hostname of the URLs are at least valid before attempting to fetch the resource.
This PR resolves #224 

## Changes

- Add a helper function for validating URIs are valid
- Ensure resource passes validator logic before attempting to fetch resource