### PR TITLE
Adding --link option to allow user to have customize link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change log level of "Video at {url} has not yet been translated into {requested_lang_code}" messages from warning to debug (way too verbose)
 - Disable preloading of subtitles in video.js
 - Add `--language-threshold` CLI argument for considering languages that appear in at least specified percentage of videos in `compute_zim_languages` (#212)
+- Add `--links` CLI argument for scraping videos from specific links (#237)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,17 @@ For the full list of arguments, see [this](ted2zim/entrypoint.py) file or run th
 ted2zim --help
 ```
 
-Example usage
+**Example usage**
+Sample of creating a ZIM for `augmented reality` topic, with a custom name, mp4 format and so on.
+
 ```bash
 ted2zim --topics="augmented reality" --debug --name="augumented_reality" --format=mp4 --title="Augmented Reality" --description="TED videos in AR category" --creator="TED" --publisher="openzim" --output="output" --keep --low-quality
+```
+
+Sample of creating a ZIM for specific URLs, with a custom name, mp4 format and so on.
+
+```bash
+ted2zim --links https://www.ted.com/talks/gautam_shah_can_the_metaverse_bring_us_closer_to_wildlife,https://www.ted.com/talks/micaela_mantegna_how_to_stop_the_metaverse_from_becoming_the_internet_s_bad_sequel --debug --name="sample_links" --format=mp4 --title="Sample Links" --description="TED talks from two different URLs" --creator="TED" --publisher="openzim" --output="output" --keep --low-quality
 ```
 
 This project can also be run with docker. Use the provided [Dockerfile](Dockerfile) or [pre-build images](https://github.com/orgs/openzim/packages/container/package/ted) to run it with Docker. See steps [here](https://docs.docker.com/get-started/part2/).

--- a/src/ted2zim/entrypoint.py
+++ b/src/ted2zim/entrypoint.py
@@ -8,19 +8,26 @@ def main():
         prog=NAME,
         description="Scraper to create ZIM files from TED talks topics or playlists",
     )
+    # Create a mutually exclusive group for content source
+    source_group = parser.add_mutually_exclusive_group(required=True)
 
-    parser.add_argument(
-        "--topics",
-        help="Comma-seperated list of topics to scrape; as given on ted.com/talks",
+    source_group.add_argument(
+        "--links",
+        help="Comma-separated TED talk URLs to scrape, each in the format: https://www.ted.com/talks/<talk_slug>",
     )
 
-    parser.add_argument(
+    source_group.add_argument(
+        "--topics",
+        help="Comma-separated list of topics to scrape; as given on ted.com/talks",
+    )
+
+    source_group.add_argument(
         "--playlist",
         help="A playlist ID from ted.com/playlists to scrape videos from",
     )
 
     parser.add_argument(
-        "--languages", help="Comma-seperated list of languages to filter videos"
+        "--languages", help="Comma-separated list of languages to filter videos"
     )
 
     parser.add_argument(
@@ -42,7 +49,7 @@ def main():
         "--subtitles",
         help=f"Language setting for subtitles. {ALL}: include all available subtitles, "
         f"{MATCHING} (default): only subtitles matching --languages, {NONE}: include no"
-        " subtitle. Also accepts comma-seperated list of language codes",
+        " subtitle. Also accepts comma-separated list of language codes",
         default=MATCHING,
         dest="subtitles_setting",
     )
@@ -189,19 +196,6 @@ def main():
     from ted2zim.scraper import Ted2Zim
 
     try:
-        if args.topics and args.playlist:
-            parser.error("--topics is incompatible with --playlist")
-        elif args.topics:
-            if args.subtitles_enough and not args.languages:
-                parser.error(
-                    "--subtitles-enough is only meant to be used if --languages is "
-                    "present"
-                )
-        elif args.playlist:
-            if args.subtitles_enough:
-                parser.error("--subtitles-enough is not compatible with playlists")
-        else:
-            parser.error("Either --topics or --playlist is required")
         if not args.subtitles_setting:
             parser.error("--subtitles cannot take an empty string")
 


### PR DESCRIPTION
## Rationale

Allow users to only get sepecific video from TED instead extract the entire topic or playlist

Usage:
```
# Replace [link1] [link2] with actual TED link
ted2zim --link [link1],[link2] --name link_test --output="output"
```

## Changes

### entrypoint.py: 
Add link option and make sure `link`, `topic` and `playlist` is mutually exclusive

### scraper.py
Add function `extract_videos_from_links` to support link fetching
Modify `run` to allow link mode