### PR TITLE
style : added minimum height for grid

### DIFF
--- a/src/ted2zim/templates/home.html
+++ b/src/ted2zim/templates/home.html
@@ -23,7 +23,8 @@
         {% endfor %}
       </select>
       <hr/>
-      <div id="grid-container" style="display:block;">
+      <div id="grid-container" style="display:block; min-height: 60vh;">
+        
       <ul id="video-items" class="rig grid"></ul>
     </div>
     <hr/>


### PR DESCRIPTION
## Rationale

The change ensures that the UI remains visually consistent even in edge cases where the number of videos is minimal (e.g., only one video or none). Without a minimum height, the grid container collapses, elements like the "Back to Top" button and the second horizontal rule (`<hr>`) to overlap or appear misaligned. By setting a minimum height, this maintain a structured and user-friendly interface regardless of the content size, improving the overall user experience and design stability. This is just a minor change none the less.

The addition of the `.prettierignore`  file ensures that the codebase remains consistent and unaffected by automatic formatting tools like Prettier, which some developers may have installed on their systems. While this could have been handled locally, adding the file to the repository ensures that all contributors work with the same formatting rules, avoiding unintended reformatting during commits. This approach promotes consistency across the team and prevents unnecessary diffs or conflicts caused by automated formatting, without impacting developers who do not use Prettier.

## Changes

- For the purpose of achieving what I wanted I just used a min-height in grid-container style
- `**` ensures that not a single file gets reformatted

## Summary
 Minimum width for the grid and added .prettierignore to ignore all the files.