### PR TITLE
Fix pagination text duplication during page navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An offliner to create ZIM :package: files from TED talks
 [![codecov](https://codecov.io/gh/openzim/ted/branch/main/graph/badge.svg)](https://codecov.io/gh/openzim/ted)
 [![PyPI version shields.io](https://img.shields.io/pypi/v/ted2zim.svg)](https://pypi.org/project/ted2zim/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ted2zim.svg)](https://pypi.org/project/ted2zim)
+[![Docker](https://ghcr-badge.egpl.dev/openzim/ted/latest_tag?label=docker)](https://ghcr.io/openzim/ted)
 
 TED (Technology, Entertainment, Design) is a global set of conferences under the slogan "ideas worth spreading". They address a wide range of topics within the research and practice of science and culture, often through storytelling. The speakers are given a maximum of 18 minutes to present their ideas in the most innovative and engaging ways they can. One can eaisly find all the TED videos [here](https://ted.com/talks).
 

--- a/src/ted2zim/templates/assets/app.js
+++ b/src/ted2zim/templates/assets/app.js
@@ -84,7 +84,7 @@ function refreshPagination() {
 	if (pageCount > 1) {
 	    var pageText = document.getElementById('pagination-text');
 	    var pageNumber = videoDB.getPageNumber();
-	    pageText.innerHTML += ' ' + pageNumber + '/' + pageCount;
+	    pageText.innerHTML = pageText.getAttribute('data-text') + ' ' + pageNumber + '/' + pageCount;
 	    
 	    if (videoDB.getPageNumber() == 1) {
 		leftArrow.style.visibility = 'hidden';

--- a/src/ted2zim/templates/home.html
+++ b/src/ted2zim/templates/home.html
@@ -32,7 +32,7 @@
     </div>
     <div id="pagination" style="visibility: hidden; margin-bottom: 1em;">
       <div id="left-arrow">&#10096;</div>
-      <span id="pagination-text">{{ pagination_text }}</span>
+      <span id="pagination-text" data-text="{{ pagination_text }}">{{ pagination_text }}</span>
       <div id="right-arrow">&#10097;</div>
     </div>
   </div>

--- a/tedPatch.patch
+++ b/tedPatch.patch
@@ -1,0 +1,26 @@
+diff --git a/src/ted2zim/templates/assets/app.js b/src/ted2zim/templates/assets/app.js
+index a70e101..f901be2 100644
+--- a/src/ted2zim/templates/assets/app.js
++++ b/src/ted2zim/templates/assets/app.js
+@@ -84,7 +84,7 @@ function refreshPagination() {
+ 	if (pageCount > 1) {
+ 	    var pageText = document.getElementById('pagination-text');
+ 	    var pageNumber = videoDB.getPageNumber();
+-	    pageText.innerHTML += ' ' + pageNumber + '/' + pageCount;
++	    pageText.innerHTML = pageText.getAttribute('data-text') + ' ' + pageNumber + '/' + pageCount;
+ 	    
+ 	    if (videoDB.getPageNumber() == 1) {
+ 		leftArrow.style.visibility = 'hidden';
+diff --git a/src/ted2zim/templates/home.html b/src/ted2zim/templates/home.html
+index 87e0ab4..3d02b54 100644
+--- a/src/ted2zim/templates/home.html
++++ b/src/ted2zim/templates/home.html
+@@ -32,7 +32,7 @@
+     </div>
+     <div id="pagination" style="visibility: hidden; margin-bottom: 1em;">
+       <div id="left-arrow">&#10096;</div>
+-      <span id="pagination-text">{{ pagination_text }}</span>
++      <span id="pagination-text" data-text="{{ pagination_text }}">{{ pagination_text }}</span>
+       <div id="right-arrow">&#10097;</div>
+     </div>
+   </div>


### PR DESCRIPTION
[Fixes #217] Fix: Fix pagination text duplication during page navigation

## Root Cause  
The pagination text was being incorrectly handled because each refresh was appending to the existing content of the `pagination-text` element, which already contained the label text. This caused the label to accumulate with each update, resulting in duplicate "Page X/Y" texts being displayed.  

## Fix  
The solution stores the static label text ("Page" or its translation) as a data attribute in the HTML element, which acts as a permanent storage. When pagination updates occur, the code retrieves this stored label and combines it with the dynamic page numbers, ensuring the label text remains consistent across all pagination updates.  

This separates the static text from the dynamic content, preventing the label from being duplicated during updates.  


https://github.com/user-attachments/assets/5e6aa49c-a00c-4bae-9338-72807b4b6716

