### PR TITLE
Fix pagination text duplication during page navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -  Restore functionality to resist temporary bad TED responses when parsing video pages (#209)
 -  Retry video data extraction if `videoData` is missing from page data (#226)
 -  Skip download of speaker image if URL is "-" (#224)
+-  Fix pagination text duplication during page navigation (#242)
 
 ## [3.0.2] - 2024-06-24
 

--- a/src/ted2zim/templates/assets/app.js
+++ b/src/ted2zim/templates/assets/app.js
@@ -84,7 +84,7 @@ function refreshPagination() {
 	if (pageCount > 1) {
 	    var pageText = document.getElementById('pagination-text');
 	    var pageNumber = videoDB.getPageNumber();
-	    pageText.innerHTML += ' ' + pageNumber + '/' + pageCount;
+	    pageText.innerHTML = pageText.getAttribute('data-text') + ' ' + pageNumber + '/' + pageCount;
 	    
 	    if (videoDB.getPageNumber() == 1) {
 		leftArrow.style.visibility = 'hidden';

--- a/src/ted2zim/templates/home.html
+++ b/src/ted2zim/templates/home.html
@@ -34,7 +34,7 @@
 
     <div id="pagination" style="visibility: hidden; margin-bottom: 1em;">
       <div id="left-arrow"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><!-- Icon from IconaMoon by Dariush Habibpour - https://creativecommons.org/licenses/by/4.0/ --><path fill="currentColor" fill-rule="evenodd" d="M15 7a1 1 0 0 0-1.707-.707l-5 5a1 1 0 0 0 0 1.414l5 5A1 1 0 0 0 15 17z" clip-rule="evenodd"/></svg></div>
-      <span id="pagination-text">{{ pagination_text }}</span>
+      <span id="pagination-text" data-text="{{ pagination_text }}">{{ pagination_text }}</span>
       <div id="right-arrow"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><!-- Icon from IconaMoon by Dariush Habibpour - https://creativecommons.org/licenses/by/4.0/ --><path fill="currentColor" fill-rule="evenodd" d="M9 17a1 1 0 0 0 1.707.707l5-5a1 1 0 0 0 0-1.414l-5-5A1 1 0 0 0 9 7z" clip-rule="evenodd"/></svg></div>
     </div>
 


### PR DESCRIPTION
[Fixes #217] Pagination Label correctly shows the page number.

## Rationale

### Root Cause  
The pagination text was being incorrectly handled because each refresh was appending to the existing content of the `pagination-text` element, which already contained the label text. This caused the label to accumulate with each update, resulting in duplicate "Page X/Y" texts being displayed.  

### Fix  
The solution stores the static label text ("Page" or its translation) as a data attribute in the HTML element, which acts as a permanent storage. When pagination updates occur, the code retrieves this stored label and combines it with the dynamic page numbers, ensuring the label text remains consistent across all pagination updates.  

This separates the static text from the dynamic content, preventing the label from being duplicated during updates.  

#### Demo Video

https://github.com/user-attachments/assets/5e6aa49c-a00c-4bae-9338-72807b4b6716

## Changes

- Updated `refreshPagination()` in `app.js` to use `data-text` instead of modifying `innerHTML` directly.
- Modified `home.html` to store the original pagination text using a `data-text` attribute.