### PR TITLE
Auto Enable Captions based on user selected language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--language-threshold` CLI argument for considering languages that appear in at least specified percentage of videos in `compute_zim_languages` (#212)
 - Add `--links` CLI argument for scraping videos from specific links (#237)
 - Circular back-to-top button and replaced text characters with icon buttons for better visual consistency (#112)
+- Sub title selection should be done according to the language selection (#207)
+- Select language is not persistent enough (#208)
 
 ### Fixed
 

--- a/src/ted2zim/scraper.py
+++ b/src/ted2zim/scraper.py
@@ -948,6 +948,7 @@ class Ted2Zim:
                 titles=titles,
                 descriptions=video["description"],
                 back_to_list=_("Back to the list"),
+                native_talk_language=video["native_talk_language"],
             )
             html_path = self.build_dir.joinpath(video["slug"])
             with open(html_path, "w", encoding="utf-8") as html_page:

--- a/src/ted2zim/templates/article.html
+++ b/src/ted2zim/templates/article.html
@@ -14,6 +14,7 @@
         <script src="assets/ogvjs/ogv.js"></script>
         <script src="assets/videojs-ogvjs.js"></script>
         <script src="assets/jquery.min.js"></script>
+        <script src="assets/utils.js"></script>
         <script src="assets/article.js"></script>
         <script src="assets/polyfills.js"></script>
         <script src="assets/webp-hero.bundle.js"></script>
@@ -26,8 +27,8 @@
             {% for title in titles %}
             <p class="title lang-{{ title.lang }}">{{ title.text }}</p>
             {% endfor %}
-            <div id="video-wrapper">
-                <video class="video-js vjs-default-skin vjs-fill"
+            <div id="video-wrapper" data-audio-lang="{{ native_talk_language }}">
+                <video id="ted-video" class="video-js vjs-default-skin vjs-fill"
                     controls preload="auto" playsinline
                     poster="videos/{{ video_id }}/thumbnail.webp"
                     data-setup='{"techOrder": ["html5", "ogvjs"], "html5": {"preloadTextTracks": false}, "ogvjs": {"base": "assets/ogvjs", "preloadTextTracks": false}, "autoplay": {% if autoplay %}true{% else %}false{% endif %}, "preload": true, "controls": true, "controlBar": {"pictureInPictureToggle":false}}'>

--- a/src/ted2zim/templates/assets/app.js
+++ b/src/ted2zim/templates/assets/app.js
@@ -1,5 +1,12 @@
-
 window.onload = function() {
+  // Check if a language is stored using the storage utility
+  let selectedLanguage = storage.getItem(SELECTED_LANGUAGE_KEY);
+
+  // If a language is stored, select it in the dropdown
+  // This ensures the dropdown reflects the stored language on page load.
+  if (selectedLanguage && selectedLanguage !== 'lang-all') {
+    $('.chosen-select').val(selectedLanguage).trigger('chosen:updated');
+  }
   setupLanguageFilter();
   setupPagination();
 
@@ -23,12 +30,16 @@ window.onload = function() {
 function setupLanguageFilter() {
   $('.chosen-select').chosen({width: "380px"}).change(function(){
     language = arguments[1].selected;
+    // Store the selected language using the storage utility
+    storage.setItem(SELECTED_LANGUAGE_KEY, language);
 
     // If 'lang-all' is selected the user wants to
     // display videos in all languages. 
     // This removes the previously set filter (if any).
     if (language == 'lang-all') {
       language = undefined;
+      // If 'lang-all' is selected, remove the stored language.
+      storage.removeItem(SELECTED_LANGUAGE_KEY);
     }
 
     // Load the data for the selected language and 

--- a/src/ted2zim/templates/assets/article.js
+++ b/src/ted2zim/templates/assets/article.js
@@ -6,15 +6,42 @@ $.urlParam = function(name){
     return decodeURI(results[1]) || 0;
 };
 
+// Function to retrieve the selected language
+function getSelectedLanguage() {
+    return storage.getItem(SELECTED_LANGUAGE_KEY) || $.urlParam('lang');
+}
+
 window.onload = function() {
-    var lang = $.urlParam('lang');
+    var lang = getSelectedLanguage();
     if (lang && lang !== "undefined") {
         document.getElementById("title-head").innerHTML = $("p.title.lang-" + lang).text();
         $(".lang-default").css("display", "none");
         $(".lang-" + lang).css("display", "block");
+
+        // Retrieve the value of the data-audio-lang attribute from the #video-wrapper element
+        const audioLang = $('#video-wrapper').attr('data-audio-lang');
+
+        if(audioLang != lang) {
+            // Enable the subtitles for the selected language
+            videojs("ted-video").ready(function () {
+                const player = this;
+                player.ready(() => {
+                    const textTracks = player.textTracks();
+                    Array.from(textTracks).some(t => {
+                        // If the track's language matches the selected language, show it
+                        if (t.language === lang) {
+                            t.mode = 'showing';
+                            return true;
+                        }
+                        return false;
+                    });
+                });
+            });
+        }
     }
 };
 
 $(document).ready(function() {
     $("#backtolist").on("click", function() { history.go(-1) });
 });
+

--- a/src/ted2zim/templates/assets/utils.js
+++ b/src/ted2zim/templates/assets/utils.js
@@ -1,0 +1,29 @@
+// Define storage constants
+const NAMESPACE = 'ted2zim';
+const SELECTED_LANGUAGE_KEY = `${NAMESPACE}.selectedLanguage`;
+
+// Shared utility functions
+const storage = {
+  isAvailable: function() {
+    try {
+      localStorage.setItem('test', 'test');
+      localStorage.removeItem('test');
+      return true;
+    } catch (e) {
+      return false;
+    }
+  },
+  setItem: function(key, value) {
+    if (this.isAvailable()) {
+      localStorage.setItem(key, value);
+    }
+  },
+  getItem: function(key) {
+    return this.isAvailable() ? localStorage.getItem(key) : null;
+  },
+  removeItem: function(key) {
+    if (this.isAvailable()) {
+      localStorage.removeItem(key);
+    }
+  }
+};

--- a/src/ted2zim/templates/home.html
+++ b/src/ted2zim/templates/home.html
@@ -43,6 +43,7 @@
   <script src="assets/chosen/chosen.jquery.js" type="text/javascript"></script>
   <script src="assets/data.js"></script>
   <script src="assets/db.js"></script>
+  <script src="assets/utils.js"></script>
   <script src="assets/app.js"></script>
   <script src="assets/webp-trigger.js"></script>
 </body>


### PR DESCRIPTION
Fixes: [#207], [#208]

### Description

This update enhances user experience by remembering the user's selected language and automatically enabling captions in that language when a TED video is loaded.

*Changes include:*

- Added utils.js to safely access `localStorage` (supports getItem, setItem, and removeItem).
- Updated app.js to write the selected language to `localStorage`.
- Modified article.js to:
  - Read the selected language on `window.onload`.
  - Automatically enable the caption track to match the stored language.


This ensures that captions in that language will be auto-enabled across video once a user selects a language.

### Testing Instructions

1. Convert TED talks to a ZIM file:

```bash
ted2zim --topics="wildlife" --debug --name="wildlife" --format=mp4 --title="Wildlife" --description="TED videos in Wildlife Category" --creator="TED" --publisher="openzim" --output="output" --keep --low-quality
```

2. Start the libkiwix server locally:

```bash
/usr/local/bin/kiwix-serve --port=8080 --library /tmp/zimlibrary/linux_library.xml --monitorLibrary
```

### Testing Instructions
1. Open the generated ZIM in Kiwix:
2. Select a language.
3. Refresh or load another video.
4. Confirm that captions are auto-enabled in the selected language.


https://github.com/user-attachments/assets/0f9fce1f-fe77-481e-af9d-e2a68718c907



### Note

Since `localStorage` might not always be available in all browser environments, it may be worth exploring server-side support for storing user preferences. As a future enhancement, I've proposed capturing **clickstream metrics** directly within the KiwixServer to better understand user behavior. See proposal: [kiwix/libkiwix#1191](https://github.com/kiwix/libkiwix/issues/1191)

