### PR TITLE
Better warnings on missing language names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Log more meaningful messages in warnings (#268)
+- Better warnings on missing language names (#269)
 
 ## [3.1.0] - 2025-07-22
 

--- a/src/ted2zim/scraper.py
+++ b/src/ted2zim/scraper.py
@@ -725,15 +725,21 @@ class Ted2Zim:
     def get_lang_code_and_name(self, json_data, url: str | None):
         player_data = json_data["playerData"]
         lang_code = json_data["language"]
-        try:
-            lang_name = [
-                lang["languageName"]
-                for lang in player_data["languages"]
-                if lang["languageCode"] == lang_code
-            ][-1]
-        except Exception as exc:
-            logger.warning(f"player data has no entry for {lang_code} at {url}: {exc}")
+        lang_names = [
+            lang["languageName"]
+            for lang in player_data["languages"]
+            if lang["languageCode"] == lang_code
+        ]
+        if len(lang_names) == 0:
+            if lang_code != "en":
+                # display warning only for non-English, we do not care about English
+                # lang name since it is "English", we know that
+                logger.warning(
+                    f"player data is missing language name for {lang_code} on {url}"
+                )
             lang_name = lang_code
+        else:
+            lang_name = lang_names[-1]
 
         return lang_code, lang_name
 


### PR DESCRIPTION
- Do not "try-catch" when we could detect before-hand that list is empty ; other errors should probably not be ignored
- Do not log a useless warning when we miss "en" language name, we will not use it anyway in later processing (probably represent 99% of the warnings which I do not watch anymore now due to their verbosity)