### PR TITLE
Do not crash the whole scrape with a `KeyError: 'metadata'` when a talk's `playerData.resources` has no `hls.metadata` entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Log more meaningful messages in warnings (#268)
 - Better warnings on missing language names (#269)
+- Do not crash the whole scrape with a `KeyError: 'metadata'` when a talk's `playerData.resources` has no `hls.metadata` entry (#261)
 
 ## [3.1.0] - 2025-07-22
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim-bookworm
-LABEL org.opencontainers.image.source https://github.com/openzim/ted
+LABEL org.opencontainers.image.source=https://github.com/openzim/ted
 
 # Install necessary packages
 RUN apt-get update \

--- a/src/ted2zim/scraper.py
+++ b/src/ted2zim/scraper.py
@@ -800,7 +800,9 @@ class Ted2Zim:
             return False
 
         langs = player_data["languages"]
-        metadata_link = player_data["resources"]["hls"]["metadata"]
+        metadata_link = player_data.get("resources", {}).get("hls", {}).get("metadata")
+        if video_link and not metadata_link:
+            logger.warning(f"metadata link is missing for {url}")
         subtitles = self.generate_subtitle_list(
             video_id, langs, lang_code, native_talk_language
         )


### PR DESCRIPTION
Fix #261 

I do not achieve to reproduce the issue, so it looks like transient inconsistency in TED HTTP response. 

We anyway do not use much the metadata (it is only used to compute subtitles offsets), so it looks like it is probably fine to ignore when metadata is missing for the time being, until we have more logs regarding when/where this happens **and** has bad consequences.