### PR TITLE
Some subtitles are missing in the ZIM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log more meaningful messages in warnings (#268)
 - Better warnings on missing language names (#269)
 - Do not crash the whole scrape with a `KeyError: 'metadata'` when a talk's `playerData.resources` has no `hls.metadata` entry (#261)
+- Some subtitles are missing in the ZIM (#262)
 
 ## [3.1.0] - 2025-07-22
 

--- a/src/ted2zim/scraper.py
+++ b/src/ted2zim/scraper.py
@@ -1320,8 +1320,9 @@ class Ted2Zim:
                 offset=video["subtitles_offset"]
             )
             if not vtt_subtitle:
-                logger.error(
-                    f"Subtitle file for {subtitle['languageCode']} could not be created"
+                logger.warning(
+                    f"Subtitle file for {subtitle['languageCode']}, downloaded from"
+                    f"{subtitle['link']}, could not be created"
                 )
                 continue
             valid_subs.append(subtitle)

--- a/src/ted2zim/utils.py
+++ b/src/ted2zim/utils.py
@@ -26,7 +26,7 @@ def update_subtitles_list(video_id, language_list):
     return language_list
 
 
-def request_url(url, json_data=None):
+def request_url(url, json_data=None, *, raise_for_status: bool = True):
     """performs an HTTP request and returns the response, either GET or POST
 
     - json_data is used as POST body when passed, otherwise a GET request is done
@@ -53,7 +53,8 @@ def request_url(url, json_data=None):
                 req = requests.get(
                     url, headers={"User-Agent": "Mozilla/5.0"}, timeout=REQUESTS_TIMEOUT
                 )
-            req.raise_for_status()
+            if raise_for_status:
+                req.raise_for_status()
             return req
         except Exception as exc:
             if req and req.status_code == HTTPStatus.NOT_FOUND:
@@ -86,7 +87,7 @@ class WebVTT:
 
     def convert(self, offset):
         """download and convert its URL to WebVTT text"""
-        req = request_url(self.url)
+        req = request_url(self.url, raise_for_status=False)
 
         if req.status_code == HTTPStatus.NOT_FOUND:
             return None


### PR DESCRIPTION
Fix #262 

Changes:
- subtitles handling logic was expecting to receive HTTP responses in all cases and handle failures on their own, while an exception was raised and swallowed by the concurrent futures