### PR TITLE
Do not download unused thumbnails and subtitles from Youtube

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not crash the whole scrape with a `KeyError: 'metadata'` when a talk's `playerData.resources` has no `hls.metadata` entry (#261)
 - Some subtitles are missing in the ZIM (#262)
 - Do not add speaker image when its URL is known '-' bad value + do not show missing speaker profession (#264)
+- Do not download unused thumbnails and subtitles from Youtube (#265, #266)
 
 ## [3.1.0] - 2025-07-22
 

--- a/src/ted2zim/scraper.py
+++ b/src/ted2zim/scraper.py
@@ -1247,6 +1247,12 @@ class Ted2Zim:
                     ).get_options(
                         target_dir=video_dir, filepath=pathlib.Path("video.%(ext)s")
                     )
+                    # override scraperlib defaults since the scraper handles these
+                    # thumbnails and subtitles separately
+                    options["writethumbnail"] = False
+                    options["write_all_thumbnails"] = False
+                    options["writesubtitles"] = False
+                    options["allsubtitles"] = False
                     with yt_dlp.YoutubeDL(options) as ydl:
                         ydl.download([youtube_id])
                     downloaded = True


### PR DESCRIPTION
Fix #265
Fix #266

By default zimscraperlib YoutubeDL options are downloading subtitles and thumbails. In this specific scraper, this is absolutely useless since the TED scraper takes care of handling these thumbnails and subtitles separately, from regular TED datasources.

This is barely visible because it materialize only when video is not yet in the optimization cache since we save only the video there and re-download from there. This is also a materialization of the disadvantages of the "zimwriterfs" approach.