### PR TITLE
Replace language combobox and fix small bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -368,8 +368,8 @@ pyrightconfig.json
 
 # assets that we download
 src/ted2zim/templates/assets/videojs/
-src/ted2zim/templates/assets/chosen/
 src/ted2zim/templates/assets/jquery.min.js
+src/ted2zim/templates/assets/tomselect/
 src/ted2zim/templates/assets/ogvjs/
 src/ted2zim/templates/assets/videojs-ogvjs.js
 src/ted2zim/templates/assets/polyfills.js

--- a/openzim.toml
+++ b/openzim.toml
@@ -10,16 +10,22 @@ source="https://github.com/videojs/video.js/releases/download/v8.23.9/video-js-8
 target_dir="videojs"
 remove = ["alt","examples",]
 
-[files.assets.actions."chosen.jquery.js"]
-action="extract_all"
-source="https://github.com/harvesthq/chosen/releases/download/v1.8.7/chosen_v1.8.7.zip"
-target_dir="chosen"
-remove = ["docsupport","chosen.proto.*","*.html","*.md"]
-
 [files.assets.actions."jquery.min.js"]
 action="get_file"
 source="https://code.jquery.com/jquery-4.0.0.min.js"
 target_file="jquery.min.js"
+
+[files.assets.actions."tom-select.js"]
+action="get_file"
+source="https://cdn.jsdelivr.net/npm/tom-select@2.6.2/dist/js/tom-select.popular.min.js"
+target_dir="tomselect"
+target_file="tom-select.popular.min.js"
+
+[files.assets.actions."tom-select.css"]
+action="get_file"
+source="https://cdn.jsdelivr.net/npm/tom-select@2.6.2/dist/css/tom-select.default.min.css"
+target_dir="tomselect"
+target_file="tom-select.default.min.css"
 
 [files.assets.actions."ogv.js"]
 action="extract_items"

--- a/src/ted2zim/scraper.py
+++ b/src/ted2zim/scraper.py
@@ -993,7 +993,10 @@ class Ted2Zim:
             {"languageName": value, "languageCode": key}
             for key, value in all_langs.items()
         ]
-        languages = sorted(languages, key=lambda x: x["languageName"])
+        # casefold for a case-insensitive sort: a plain sort puts every
+        # uppercase-first native name (e.g. "Deutsch") before every
+        # lowercase-first one (e.g. "français"), which reads as a broken order
+        languages = sorted(languages, key=lambda x: x["languageName"].casefold())
         html = env.get_template("home.html").render(
             languages=languages,
             page_title=_("TED Talks"),
@@ -1088,10 +1091,15 @@ class Ted2Zim:
                     )
 
     def _get_video_languages(self, video):
-        """Helper Function to collect languages per video"""
+        """Helper Function to collect languages per video
+
+        Includes both audio languages and subtitle languages: the home page
+        language filter (render_home_page) lists both, so a data_{lang}.js file
+        must be generated for each or selecting a subtitle-only language 404s.
+        """
         return {
             lang["languageCode"]
-            for lang in video.get("languages", [])
+            for lang in video.get("languages", []) + video.get("subtitles", [])
             if "languageCode" in lang
         }
 
@@ -1099,7 +1107,10 @@ class Ted2Zim:
         for item in items:
             if item["lang"] == lang:
                 return item["text"]
-        return None
+        # no dedicated translation for this language (e.g. a subtitle-only
+        # language the talk page itself was never fetched in) ; fall back to
+        # whatever title is available rather than leaving it blank
+        return items[0]["text"] if items else None
 
     def download_jpeg_image_and_convert(self, url, fpath, preset_options, resize=None):
         """downloads a JPEG image and convert to proper format
@@ -1454,15 +1465,31 @@ class Ted2Zim:
 
             # Process the video data
             if self.update_videos_list_from_info(json_data, url):
-                # Try to get the talk in other languages if source_languages specified
+                lang_code = json_data["language"]
+                player_data = json_data["playerData"]
+
                 if self.source_languages:
-                    urls = self.generate_urls_for_other_languages(
-                        url, self.source_languages
-                    )
+                    # Only the explicitly requested languages
+                    other_languages = [
+                        code for code in self.source_languages if code != lang_code
+                    ]
+                else:
+                    # No languages were specified: fetch every language edition
+                    # TED has for this talk (same behavior as playlist/topic
+                    # scraping), otherwise title/description never get
+                    # translated even though subtitles are fetched
+                    other_languages = [
+                        language["languageCode"]
+                        for language in player_data["languages"]
+                        if language["languageCode"] != lang_code
+                    ]
+
+                if other_languages:
+                    urls = self.generate_urls_for_other_languages(url, other_languages)
                     for lang_url in urls:
-                        json_data = self.extract_info_from_video_page(lang_url)
-                        if json_data:
-                            self.update_videos_list_from_info(json_data, lang_url)
+                        lang_json_data = self.extract_info_from_video_page(lang_url)
+                        if lang_json_data:
+                            self.update_videos_list_from_info(lang_json_data, lang_url)
             logger.debug(f"Processed {url}")
 
         # Process finished

--- a/src/ted2zim/templates/assets/app.js
+++ b/src/ted2zim/templates/assets/app.js
@@ -1,3 +1,6 @@
+// TomSelect instance for the language filter, created in setupLanguageFilter()
+var languageSelect;
+
 window.onload = function () {
   // Check if a language is stored using the storage utility
   let selectedLanguage = storage.getItem(SELECTED_LANGUAGE_KEY) || "en";
@@ -7,9 +10,9 @@ window.onload = function () {
   setupLanguageFilter();
   setupPagination();
 
-  $('.chosen-select').val(selectedLanguage).trigger('chosen:updated');
+  languageSelect.setValue(selectedLanguage, true); // silent: avoid a duplicate loadData below
   videoDB.resetPage();
-  // Load the initial data. 
+  // Load the initial data.
   // This will load the data_{lang}.js data
   videoDB.loadData(selectedLanguage, function () {
     var data = videoDB.getPage(videoDB.getPageNumber());
@@ -19,18 +22,25 @@ window.onload = function () {
 
 };
 
-/** 
+/**
  * Apply a language filter, that is selected by the
- * drop down options <select> menu. 
+ * drop down options <select> menu (enhanced with TomSelect for
+ * type-anywhere-in-the-label search).
  * This will then only display items that have
  * subtitles in the selected language.
  */
 function setupLanguageFilter() {
-  $('.chosen-select').chosen({ width: "380px" }).change(function (_, params) {
-    var language = params.selected;
+  languageSelect = new TomSelect('#language-select', {
+    create: false,
+    maxOptions: null, // TED has 100+ languages, don't cap the unfiltered list
+    // moves the search box into the dropdown itself, always starting empty,
+    // instead of mixing it with the current value inline in the control
+    plugins: ['dropdown_input'],
+  });
+  languageSelect.on('change', function (language) {
     // Store the selected language using the storage utility
     storage.setItem(SELECTED_LANGUAGE_KEY, language);
-    // Load the data for the selected language and 
+    // Load the data for the selected language and
     // generate the video list.
     videoDB.resetPage();
     videoDB.loadData(language, function () {
@@ -71,7 +81,7 @@ function setupPagination() {
 }
 
 /**
- * Reset the page text on the pagination widget, 
+ * Reset the page text on the pagination widget,
  * if a new language has been applied.
  */
 function refreshPagination() {
@@ -105,7 +115,7 @@ function refreshPagination() {
 }
 
 /**
- * Dynamically generate the video item out of 
+ * Dynamically generate the video item out of
  * the passed in {pageData} parameter.
  * @param {pageData} Video data for the current page.
  */

--- a/src/ted2zim/templates/assets/app.js
+++ b/src/ted2zim/templates/assets/app.js
@@ -59,7 +59,7 @@ function setupPagination() {
 
   function handlePagination() {
     var data = videoDB.getPage(videoDB.getPageNumber());
-    refreshVideos(undefined, data);
+    refreshVideos(data);
     refreshPagination();
     window.scrollTo(0, 0);
   }

--- a/src/ted2zim/templates/assets/article.js
+++ b/src/ted2zim/templates/assets/article.js
@@ -27,9 +27,17 @@ function getSelectedLanguage() {
 window.onload = function() {
     var lang = getSelectedLanguage();
     if (lang && lang !== "undefined") {
-        document.getElementById("title-head").innerHTML = $("p.title.lang-" + lang).text();
-        $(".lang-default").css("display", "none");
-        $(".lang-" + lang).css("display", "block");
+        var langTitle = $("p.title.lang-" + lang);
+        // Only switch to the selected language's title/description if this
+        // specific talk actually has one (e.g. it was fetched as an audio
+        // language) ; a talk can have many more subtitle languages than
+        // title/description translations, so keep showing the default
+        // language instead of hiding everything when there's no match.
+        if (langTitle.length) {
+            document.getElementById("title-head").innerHTML = langTitle.text();
+            $(".lang-default").css("display", "none");
+            $(".lang-" + lang).css("display", "block");
+        }
 
         // Retrieve the value of the data-audio-lang attribute from the #video-wrapper element
         const audioLang = $('#video-wrapper').attr('data-audio-lang');
@@ -57,4 +65,3 @@ window.onload = function() {
 $(document).ready(function () {
     $("#backtolist").on("click", function () { history.go(-1) });
 });
-

--- a/src/ted2zim/templates/assets/home.css
+++ b/src/ted2zim/templates/assets/home.css
@@ -352,11 +352,17 @@ a.nostyle:active {
     color: #000000;
 }
 
-.chosen-container.chosen-container-single {
-    width: 240px !important;
+.ts-wrapper {
+    width: 240px;
 }
 
 @media (prefers-color-scheme: dark) {
+    :root {
+        /* lets the browser pick sensible native colors for scrollbars etc.
+           without hand-styling them */
+        color-scheme: dark;
+    }
+
     body {
         background: #121212;
         color: #e8e8e8;
@@ -380,30 +386,38 @@ a.nostyle:active {
         color: #e8e8e8;
     }
 
-    .chosen-container-single .chosen-single,
-    .chosen-container-active.chosen-with-drop .chosen-single {
-        background: #2a2a2a;
-        border-color: #555;
+    .ts-dropdown,
+    .ts-control,
+    .ts-control input {
         color: #e8e8e8;
+    }
+
+    .ts-control,
+    .ts-wrapper.single .ts-control,
+    .ts-wrapper.single.input-active .ts-control,
+    .full .ts-control,
+    .plugin-dropdown_input.focus.dropdown-active .ts-control {
+        background: #2a2a2a;
+        background-image: none;
+        border-color: #555;
         box-shadow: none;
     }
 
-    .chosen-container-single .chosen-default {
-        color: #999;
+    .ts-wrapper.single .ts-control::after {
+        border-color: #999 transparent transparent transparent;
     }
 
-    .chosen-container .chosen-drop {
+    .ts-wrapper.single.dropdown-active .ts-control::after {
+        border-color: transparent transparent #999 transparent;
+    }
+
+    .ts-dropdown {
         background: #2a2a2a;
         border-color: #555;
     }
 
-    .chosen-container .chosen-results {
-        color: #e8e8e8;
-    }
-
-    .chosen-container-single .chosen-search input[type="text"] {
-        background-color: #1e1e1e;
-        border-color: #555;
+    .ts-dropdown .active {
+        background-color: #3a3a3a;
         color: #e8e8e8;
     }
 }

--- a/src/ted2zim/templates/home.html
+++ b/src/ted2zim/templates/home.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{page_title}}</title>
     <link id="favicon" rel="shortcut icon" href="favicon.png" type="image/png">
-    <link href="assets/chosen/chosen.min.css" rel="stylesheet" type="text/css">
+    <link href="assets/tomselect/tom-select.default.min.css" rel="stylesheet" type="text/css">
     <link href="assets/home.css" rel="stylesheet" type="text/css">
     <script src="assets/polyfills.js"></script>
     <script src="assets/webp-hero.bundle.js"></script>
@@ -15,8 +15,8 @@
   <body>
     <div class="container">
       <img src="assets/img/TED.png" id="title-img" alt="TED"/>
-      <select data-placeholder="Language" class="chosen-select" tabindex="0">
-        <option value=""></option>{% for language in languages %}
+      <select id="language-select" aria-label="Language">
+        {% for language in languages %}
           <option value="{{ language.languageCode }}">{{ language.languageName }}</option>
         {% endfor %}
       </select>
@@ -38,7 +38,7 @@
 
   </div>
   <script src="assets/jquery.min.js" type="text/javascript"></script>
-  <script src="assets/chosen/chosen.jquery.js" type="text/javascript"></script>
+  <script src="assets/tomselect/tom-select.popular.min.js"></script>
   <script src="assets/db.js"></script>
   <script src="assets/utils.js"></script>
   <script src="assets/app.js"></script>


### PR DESCRIPTION
So far, combobox was based in jQuery [Chosen](https://github.com/harvesthq/chosen). This is unmaintained since 2018.

This PR:
- remove Chosen and add TomSelect instead
- fix a bug around handling of language when pagination
- fix a bug around retrieval of all languages when passing a video link (instead of only EN)
- fix a bug around fallbacks when selected language is not available for a given video